### PR TITLE
Candidate fix to normalize for ragged rows

### DIFF
--- a/src/grafter/csv.clj
+++ b/src/grafter/csv.clj
@@ -184,7 +184,7 @@ into data rows look like this.  It does not yet preserve the header row:
                         (let [rowv (->> row (take srange) (apply vector))]
                           (-> rowv
                               (conj (nth header-row id))
-                              (conj (nth row id)))))
+                              (conj (get (vec row) id)))))
 
         expand-rows (fn [row] (map normalise-row colids (repeat ncols row)))]
 


### PR DESCRIPTION
Just came across this idea in Joy of Clojure: instead of using `nth` we can use `get` which returns `nil` instead of throwing an out of bounds exception. I had to cast the row to a vector first - not sure if this has any unintended consequences for the data or performance.
