### PR TITLE
Remove reflection warnings from sesame.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,5 +39,6 @@
                              [codox "0.8.10"]]
 
                    :dependencies [[com.aphyr/prism "0.1.1"]]
+                   :global-vars {*warn-on-reflection* true}
 
                    :env {:dev true}}})


### PR DESCRIPTION
Set the global var _warn-on-reflection_ in the development profile
which will warn at compile time when reflection is required at runtime
to resolve method calls.

Fix all the resulting reflection warnings in sesame.clj.
