### PR TITLE
All columns on single row ds

### DIFF
--- a/src/tabular/grafter/tabular.clj
+++ b/src/tabular/grafter/tabular.clj
@@ -86,7 +86,10 @@
   (let [not-found-items (invalid-column-keys dataset cols)]
     (if (and (empty? not-found-items)
             (some identity cols))
-      (inc/$ cols dataset)
+      (let [inc-ds (inc/$ cols dataset)]
+        (if (inc/dataset? inc-ds)
+          inc-ds
+          (make-dataset inc-ds cols)))
       (throw (IndexOutOfBoundsException. (str "The columns: " (str/join ", " not-found-items) " are not currently defined."))))))
 
 (defn- indexed [col]
@@ -499,7 +502,7 @@ the specified column being cloned."
      (build-lookup-table dataset key-cols nil))
 
   ([dataset key-cols return-keys]
-     (let [key-cols (resolve-key-cols dataset( lift->vector key-cols))
+     (let [key-cols (resolve-key-cols dataset (lift->vector key-cols))
            return-keys (resolve-all-col-ids dataset
                                             (if (nil? return-keys)
                                               (remaining-keys dataset key-cols)

--- a/src/tabular/grafter/tabular.clj
+++ b/src/tabular/grafter/tabular.clj
@@ -89,7 +89,7 @@
       (let [inc-ds (inc/$ cols dataset)]
         (if (inc/dataset? inc-ds)
           inc-ds
-          (make-dataset inc-ds cols)))
+          (make-dataset [inc-ds] cols)))
       (throw (IndexOutOfBoundsException. (str "The columns: " (str/join ", " not-found-items) " are not currently defined."))))))
 
 (defn- indexed [col]

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -229,8 +229,11 @@
                      (all-columns test-data (range 100))))))
 
     (testing "still returns a dataset even with only one row"
-      (let [test-data (make-dataset [["Doc Brown" "Einstein"]] ["Owner" "Dog"])]
-        (is (inc/dataset? (all-columns test-data ["Owner" "Dog"])))))))
+      (let [test-data (make-dataset [["Doc Brown" "Einstein"]] ["Owner" "Dog"])
+            result (all-columns test-data ["Owner" "Dog"])]
+        (is (is-a-dataset? result))
+
+        (is (= test-data result))))))
 
 (deftest rows-tests
   (let [test-data (test-dataset 10 2)]
@@ -426,6 +429,10 @@
       (is (= {"age" 25 "debt" 33}
              ((build-lookup-table debts "name") "rick")
              ((build-lookup-table debts ["name"]) "rick"))))
+
+    (testing "with no specified return column and one row only"
+      (is (= {"age" 25 "debt" 33}
+             ((build-lookup-table (take-rows debts 1) "name") "rick"))))
 
     (testing "1 key column"
       (is (= {"debt" 20}

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -226,7 +226,11 @@
                    (all-columns test-data (range 100))))
       (testing "is the default"
         (is (thrown? IndexOutOfBoundsException
-                     (all-columns test-data (range 100))))))))
+                     (all-columns test-data (range 100))))))
+
+    (testing "still returns a dataset even with only one row"
+      (let [test-data (make-dataset [["Doc Brown" "Einstein"]] ["Owner" "Dog"])]
+        (is (inc/dataset? (all-columns test-data ["Owner" "Dog"])))))))
 
 (deftest rows-tests
   (let [test-data (test-dataset 10 2)]
@@ -443,7 +447,6 @@
              ((build-lookup-table debts ["name" "age"] "debt") ["rick" 25])))
       (is (= nil
              ((build-lookup-table debts ["name" "age"] "debt") ["foo" 99]))))
-
 
     ;; TODO when we find a better error handling approach we should
     ;; support it here too.


### PR DESCRIPTION
If you pass a dataset with one row to `(inc/$ cols dataset)` then it returns a seq, not a dataset with one row. This PR attempts to guard against this.