### PR TITLE
Fix for issue #19. all-columns / columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 /tmp/
 .DS_Store
 /api-docs
+*.iml
+.idea/

--- a/src/tabular/grafter/tabular.clj
+++ b/src/tabular/grafter/tabular.clj
@@ -55,7 +55,7 @@
                              (map first))]
     not-found-items))
 
-(defn all-columns
+(defn- all-columns
   "Takes a dataset and any number of integers corresponding to column
   numbers and returns a dataset containing only those columns.
 
@@ -69,12 +69,14 @@
  [dataset cols]
   (let [not-found-items (invalid-column-keys dataset cols)]
     (if (and (empty? not-found-items)
-            (some identity cols))
+             (some identity cols))
       (let [inc-ds (inc/$ cols dataset)]
         (if (inc/dataset? inc-ds)
           (with-meta inc-ds (meta dataset))
           (with-meta (make-dataset [inc-ds] cols) (meta dataset))))
-      (throw (IndexOutOfBoundsException. (str "The columns: " (str/join ", " not-found-items) " are not currently defined."))))))
+      (throw (IndexOutOfBoundsException. (str "The columns: "
+                                              (str/join ", " not-found-items)
+                                              " are not currently defined."))))))
 
 (defn- indexed [col]
   (map-indexed vector col))
@@ -146,19 +148,18 @@
   "Given a dataset and some columns, narrow the dataset to just the
   supplied columns.
 
-  Supplied cols are paired off with columns in the data and then a selection is
-  done. Any cols left over after the pairing are discarded, but if a selected col
+  Supplied cols matched with columns in the data and then a selection is done.
+  Any cols left over after the pairing are discarded, but if a selected col
   is not actually in the data an IndexOutOfBoundsException will be thrown.
 
   This function can safely be used with infinite sequences."
-
   [dataset cols]
   (let [col-names (column-names dataset)
         max-cols (count (:column-names dataset))
-        matched-column-pos (->>
+        matched-col-positions (->>
                              (take max-cols cols)
                              (map (partial col-position col-names)))
-        valid-positions (filterv #(not= ::not-found %) matched-column-pos)
+        valid-positions (filterv #(not= ::not-found %) matched-col-positions)
         selected-cols (map #(nth col-names %) valid-positions)]
     (all-columns dataset selected-cols)))
 

--- a/src/tabular/grafter/tabular.clj
+++ b/src/tabular/grafter/tabular.clj
@@ -56,17 +56,17 @@
     not-found-items))
 
 (defn- all-columns
-  "Takes a dataset and any number of integers corresponding to column
-  numbers and returns a dataset containing only those columns.
+  "Takes a dataset and a finite sequence of column identifiers.
 
   If you want to use infinite sequences of columns or allow the
   specification of more cols than are in the data without error you
   should use columns instead.  Using an infinite sequence with this
   function will result in non-termination.
 
-  One advantage of this over using columns is that you can duplicate
-  an arbitrary number of columns."
- [dataset cols]
+  Unlike the columns function this function will raise an
+  IndexOutOfBoundsException if a specified column is not actually
+  found in the Dataset."
+  [dataset cols]
   (let [not-found-items (invalid-column-keys dataset cols)]
     (if (and (empty? not-found-items)
              (some identity cols))
@@ -145,20 +145,17 @@
         ::not-found))))
 
 (defn columns
-  "Given a dataset and some columns, narrow the dataset to just the
-  supplied columns.
+  "Given a dataset and a sequence of column identifiers, narrow the
+  dataset to just the supplied columns.
 
-  Supplied cols matched with columns in the data and then a selection is done.
-  Any cols left over after the pairing are discarded, but if a selected col
-  is not actually in the data an IndexOutOfBoundsException will be thrown.
-
-  This function can safely be used with infinite sequences."
+  The supplied sequence of columns are first cropped to the number of
+  columns in the dataset before being selected, this means that
+  infinite sequences can safely supplied to this function."
   [dataset cols]
   (let [col-names (column-names dataset)
         max-cols (count (:column-names dataset))
-        matched-col-positions (->>
-                             (take max-cols cols)
-                             (map (partial col-position col-names)))
+        matched-col-positions (->> (take max-cols cols)
+                                   (map (partial col-position col-names)))
         valid-positions (filterv #(not= ::not-found %) matched-col-positions)
         selected-cols (map #(nth col-names %) valid-positions)]
     (all-columns dataset selected-cols)))

--- a/src/tabular/grafter/tabular.clj
+++ b/src/tabular/grafter/tabular.clj
@@ -102,23 +102,23 @@
        (= ::not-found current-item-number)) []
 
        (= current-item-number index) (let [[repeated-item-numbers remaining-item-numbers]
-                                      (split-with #(= current-item-number %) item-numbers)
-                                      repeated-items (repeat (count repeated-item-numbers) current-item)]
-                                  (lazy-cat
-                                   repeated-items
-                                   (select-indexed item-data remaining-item-numbers)))
+                                           (split-with #(= current-item-number %) item-numbers)
+                                           repeated-items (repeat (count repeated-item-numbers) current-item)]
+                                       (lazy-cat
+                                         repeated-items
+                                         (select-indexed item-data remaining-item-numbers)))
 
        (< current-item-number index) (select-indexed
-                                     (drop-while (fn [[index item]]
-                                                   (not= index current-item-number))
-                                                 item-data)
-                                     rest-item-numbers)
+                                       (drop-while (fn [[index item]]
+                                                     (not= index current-item-number))
+                                                   item-data)
+                                       rest-item-numbers)
        (> current-item-number index) (select-indexed
-                                     (drop-while (fn [[index item]]
-                                                   (not= index current-item-number))
-                                                 item-data)
-                                     ;; leave item-numbers as is (i.e. stay on current item after fast forwarding the data)
-                                     item-numbers)))
+                                       (drop-while (fn [[index item]]
+                                                     (not= index current-item-number))
+                                                   item-data)
+                                       ;; leave item-numbers as is (i.e. stay on current item after fast forwarding the data)
+                                       item-numbers)))
 
 (defn rows
   "Takes a dataset and a seq of row-numbers and returns a dataset
@@ -146,18 +146,20 @@
   "Given a dataset and some columns, narrow the dataset to just the
   supplied columns.
 
-  cols are paired off with columns in the data and then a selection is
-  done.  Any cols left over after the pairing are discarded, but if a
-  selected col is not actually in the data an IndexOutOfBoundsException will
-  be thrown.
+  Supplied cols are paired off with columns in the data and then a selection is
+  done. Any cols left over after the pairing are discarded, but if a selected col
+  is not actually in the data an IndexOutOfBoundsException will be thrown.
 
   This function can safely be used with infinite sequences."
 
   [dataset cols]
   (let [col-names (column-names dataset)
-        matched-columns (->> cols
+        max-cols (count (:column-names dataset))
+        matched-column-pos (->>
+                             (take max-cols cols)
                              (map (partial col-position col-names)))
-        selected-cols (select-indexed (indexed col-names) matched-columns)]
+        valid-positions (filterv #(not= ::not-found %) matched-column-pos)
+        selected-cols (map #(nth col-names %) valid-positions)]
     (all-columns dataset selected-cols)))
 
 (defn rename-columns

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -297,7 +297,27 @@
                                       ["a" "b" "d" "c"])]
           (is (= expected-dataset
                  (columns test-data [:a :b :d :c]))
-              "should return dataset containing the cols :a :b :d :c"))))))
+              "should return dataset containing the cols :a :b :d :c")))
+
+      (testing "Duplicate columns in the selection leads to duplicated column-names"
+        ;; NOTE that these behaviour's aren't really desirable - but its
+        ;; hard to prevent without using only finite sequences for
+        ;; selection.
+        ;;
+        ;; These tests are primarily to document this behaviour - even
+        ;; though it can be undesirable.
+        (let [expected-dataset (make-dataset [[0 0] [1 1]]
+                                             ["a" "a"])
+              test-dataset (test-dataset 2 2)
+
+              result (columns test-dataset ["a" "a"])]
+          (is (= ["a" "a"] (column-names result)))
+          (is (= expected-dataset result))
+          ;; Columns crops the supplied sequence to the data.
+          ;; This means duplicate columns may sneak in.
+          (is (= expected-dataset (columns test-dataset ["a" "a" "b"]))))))))
+
+
 
 (deftest rows-tests
   (let [test-data (test-dataset 10 2)]

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -223,6 +223,8 @@
            :not-found "z"
            :not-found :z))))
 
+
+;; Merge column test with all-columns
 (deftest columns-tests
   (let [expected-dataset (test-dataset 5 2)
         test-data (test-dataset 5 10)]
@@ -250,7 +252,15 @@
         (let [md {:foo :bar}
               ds (with-meta (make-dataset [[1 2 3]]) md)]
           (is (= md
-                 (meta (columns ds [0])))))))))
+                 (meta (columns ds [0]))))))
+
+      (testing "Returns all columns from unordered sequence"
+        (let [expected-dataset (assoc (test-dataset 5 4)
+                                      :column-names
+                                      ["a" "b" "d" "c"])]
+          (is (= expected-dataset
+                 (columns test-data [:a :b :d :c]))
+              "should return dataset containing the cols :a :b :d :c"))))))
 
 (deftest all-columns-test
   (testing "all-columns"

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -20,6 +20,20 @@
           (testing "and the second item is the source data without the first row"
             (is (= (rest raw-data) (second retval)))))))))
 
+(= (make-dataset '({"a" 1, "b" 2}
+                   {"a" 3, "b" 4, "c" 5})
+                 ["a" "b" "c"])
+   (make-dataset '({"a" 1, "b" 2, "c" nil}
+                   {"a" 3, "b" 4, "c" 5})
+                 ["a" "b" "c"]))
+
+(= (make-dataset '({"a" 1, "b" 2, "c" 5}
+                   {"a" 3, "b" 4})
+                  ["a" "b" "c"])
+   (make-dataset '({"a" 1, "b" 2, "c" 5}
+                   {"a" 3, "b" 4, "c" nil})
+                  ["a" "b" "c"]))
+
 (deftest make-dataset-tests
   (testing "make-dataset"
     (let [raw-data [[1 2 3] [4 5 6]]
@@ -47,6 +61,21 @@
         (is (= ds2
                (make-dataset ds1 ["c" "d"]))))
 
+      (testing "making a dataset with ragged rows"
+        (is (= (make-dataset '({"a" 1, "b" 2}
+                               {"a" 3, "b" 4, "c" 5})
+                              ["a" "b" "c"])
+               (make-dataset '({"a" 1, "b" 2, "c" nil}
+                               {"a" 3, "b" 4, "c" 5})
+                              ["a" "b" "c"])))
+
+        (is (= (make-dataset '({"a" 1, "b" 2, "c" 5}
+                               {"a" 3, "b" 4})
+                              ["a" "b" "c"])
+               (make-dataset '({"a" 1, "b" 2, "c" 5}
+                               {"a" 3, "b" 4, "c" nil})
+                              ["a" "b" "c"]))))
+
       (testing "making a dataset with empty rows"
         (let [dataset (make-dataset '((1 2) () ()) ["a" "b"])
               expected (make-dataset '((1 2) (nil nil) (nil nil)) ["a" "b"])]
@@ -59,6 +88,7 @@
           (is (= (meta (make-dataset ds))
                  md)
               "Copy metadata when making a new dataset"))))))
+
 
 
 ;;; These two vars define what the content of the files
@@ -308,7 +338,7 @@
     (let [dataset (test-dataset 3 1)]
       (is (= (make-dataset [[1] [2]]) (drop-rows dataset 1)))
       (is (= (make-dataset [[2]]) (drop-rows dataset 2)))
-      (is (= (make-dataset []) (drop-rows dataset 1000)))))
+      (is (= (make-dataset [] ["a"]) (drop-rows dataset 1000)))))
 
   (testing "preserves metadata"
       (let [md {:foo :bar}
@@ -470,12 +500,20 @@
   (let [subject (make-dataset [[1 2 3] [4 5 6]])]
     (testing "add-columns"
       (testing "with hash-map"
-        (is (= (make-dataset [[1 2 3 "kitten" "trousers"]
-                              [4 5 6 "kitten" "trousers"]]
-                             ["a" "b" "c" "animal" "clothes"])
+        (testing "fully populated"
+          (is (= (make-dataset [[1 2 3 "kitten" "trousers"]
+                                [4 5 6 "kitten" "trousers"]]
+                               ["a" "b" "c" "animal" "clothes"])
 
-               (add-columns subject {"animal" "kitten" "clothes" "trousers"}))
-            "adds cells to every row of the specified columns"))
+                 (add-columns subject {"animal" "kitten" "clothes" "trousers"}))
+              "adds cells to every row of the specified columns"))
+
+        (testing "where the first row of data has no value in the lookup"
+          (is (= (make-dataset [[1 2 3 nil]
+                                [4 5 6 "yes"]]
+                               ["a" "b" "c" "above_4"])
+                 (add-columns subject ["above_4"] ["a"] {4 {"above_4" "yes"}}))
+              "adds columns to every row")))
 
       (testing "with function"
         (testing "with 1 argument"

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -224,7 +224,6 @@
            :not-found :z))))
 
 
-;; Merge column test with all-columns
 (deftest columns-tests
   (let [expected-dataset (test-dataset 5 2)
         test-data (test-dataset 5 10)]
@@ -245,7 +244,8 @@
         (is (columns test-data (grafter.sequences/integers-from 5))
             "Takes as much as it can from the supplied sequence and returns those columns.")
 
-        (is (thrown? IndexOutOfBoundsException (columns test-data (range 10 100)))
+        (is (thrown? IndexOutOfBoundsException
+                     (columns test-data (range 10 100)))
             "Raises an exception if columns when paired with data are not actually column headings."))
 
       (testing "preserves metadata"
@@ -254,6 +254,13 @@
           (is (= md
                  (meta (columns ds [0]))))))
 
+      (testing "still returns a dataset even with only one row"
+        (let [test-data (make-dataset [["Doc Brown" "Einstein"]] ["Owner" "Dog"])
+              result (columns test-data ["Owner" "Dog"])]
+          (is (is-a-dataset? result))
+
+          (is (= test-data result))))
+
       (testing "Returns all columns from unordered sequence"
         (let [expected-dataset (assoc (test-dataset 5 4)
                                       :column-names
@@ -261,28 +268,6 @@
           (is (= expected-dataset
                  (columns test-data [:a :b :d :c]))
               "should return dataset containing the cols :a :b :d :c"))))))
-
-(deftest all-columns-test
-  (testing "all-columns"
-    (let [test-data (test-dataset 5 5)]
-      (is (thrown? IndexOutOfBoundsException
-                   (all-columns test-data (range 100))))
-      (testing "is the default"
-        (is (thrown? IndexOutOfBoundsException
-                     (all-columns test-data (range 100))))))
-
-    (testing "still returns a dataset even with only one row"
-      (let [test-data (make-dataset [["Doc Brown" "Einstein"]] ["Owner" "Dog"])
-            result (all-columns test-data ["Owner" "Dog"])]
-        (is (is-a-dataset? result))
-
-        (is (= test-data result))))
-
-    (testing "preserves metadata"
-      (let [md {:foo :bar}
-            ds (with-meta (make-dataset [[1 2 3]]) md)]
-        (is (= md
-               (meta (all-columns ds [0]))))))))
 
 (deftest rows-tests
   (let [test-data (test-dataset 10 2)]
@@ -316,7 +301,7 @@
         (let [md {:foo :bar}
               ds (with-meta (make-dataset [[1 2 3]]) md)]
           (is (= md
-                 (meta (all-columns ds [0])))))))))
+                 (meta (rows ds [0])))))))))
 
 (deftest drop-rows-test
   (testing "drop-rows"


### PR DESCRIPTION
Fix for issue #19. all-columns / columns should crop infinite sequence and handle unordered column request seq.

Concerning `select-indexed` function in `tabular.clj`: I left it alone in the end, because it is a dependency of the `rows` function, but `columns` is no longer calling it and now only `rows` is using it; however that function was the crux of the issue and remains potentially ripe for removal as well as a source for suspicion.

`select-indexed`  was originally crafted to work for rows and cols.... which seems to have compounded complexity. But I'd like to look at rows in more detail to be sure. Would like to discuss its removal in the future, and if not removal, let's improve and (if possible) simplify the implementation.