### PR TITLE
Add ->to-grafter-url implementation for org.openrdf.model URI

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  [org.clojure/tools.logging "0.3.1"]
 
                  [org.clojure/algo.monads "0.1.5"]
-                 [grafter/url "0.1.0-SNAPSHOT"]
+                 [grafter/url "0.2.0-SNAPSHOT"]
                  [clj-time "0.7.0"]
 
                  ;; Shouldn't need this, but somehow excluded and required by SPARQLRepository

--- a/src/rdf-common/grafter/rdf/io.clj
+++ b/src/rdf-common/grafter/rdf/io.clj
@@ -1,12 +1,12 @@
 (ns grafter.rdf.io
-  "Functions & Protocols for serializing Grafter Statements into
+  "Functions & Protocols for serializing Grafter Statements to (and from)
   any Linked Data format supported by Sesame."
   (:require [clojure.java.io :as io]
             [grafter.rdf.protocols :as pr]
             [clojure.tools.logging :as log]
             [me.raynes.fs :as fs]
             [pantomime.media :as mime]
-            [grafter.url :refer [->url IURIable]])
+            [grafter.url :refer [->url ->grafter-url IURIable ToGrafterURL]])
   (:import (grafter.rdf.protocols IStatement Quad Triple)
            (grafter.url GrafterURL)
            (java.io File)
@@ -515,3 +515,11 @@
                                            {:type :reading-aborted} msg))
                            (sesame-statement->IStatement msg)))]
           (map read-rdf statements))))))
+
+(extend-protocol ToGrafterURL
+
+  URI
+  (->grafter-url [uri]
+    (-> uri
+        str
+        ->grafter-url)))

--- a/src/rdf-repository/grafter/rdf/repository.clj
+++ b/src/rdf-repository/grafter/rdf/repository.clj
@@ -379,31 +379,30 @@
                                          sparql-string)]
       (.execute prepared-query))))
 
-(defn- ->uri [graph]
-  (if (instance? URI graph)
-    graph
-    (URIImpl. graph)))
-
 (defn make-restricted-dataset
   "Build a dataset to act as a graph restriction.  You can specify for
   both `:default-graph` and `:named-graphs`.  Both of which take sequences
   of URI strings."
   [& {:as options}]
-  (when options
-    (let [{:keys [default-graph named-graphs]
-           :or {default-graph [] named-graphs []}} options
-           private-graph "urn:private-graph-to-force-restrictions-when-no-graphs-are-listed"
-           dataset (DatasetImpl.)]
-      (if (string? default-graph)
-        (.addDefaultGraph dataset (->uri default-graph))
+  (let [->uri (fn [graph]
+                (if (instance? URI graph)
+                  graph
+                  (URIImpl. graph)))]
+    (when options
+      (let [{:keys [default-graph named-graphs]
+             :or   {default-graph [] named-graphs []}} options
+            private-graph "urn:private-graph-to-force-restrictions-when-no-graphs-are-listed"
+            dataset (DatasetImpl.)]
+        (if (string? default-graph)
+          (.addDefaultGraph dataset (->uri default-graph))
 
-        (doseq [graph (conj default-graph private-graph)]
-          (.addDefaultGraph dataset (->uri graph))))
-      (if (string? named-graphs)
-        (.addNamedGraph dataset (->uri named-graphs))
-        (doseq [graph named-graphs]
-          (.addNamedGraph dataset (->uri graph))))
-      dataset)))
+          (doseq [graph (conj default-graph private-graph)]
+            (.addDefaultGraph dataset (->uri graph))))
+        (if (string? named-graphs)
+          (.addNamedGraph dataset (->uri named-graphs))
+          (doseq [graph named-graphs]
+            (.addNamedGraph dataset (->uri graph))))
+        dataset))))
 
 (defn- mapply [f & args]
   (apply f (apply concat (butlast args) (last args))))

--- a/test/grafter/rdf/io_test.clj
+++ b/test/grafter/rdf/io_test.clj
@@ -4,7 +4,8 @@
             [grafter.rdf :refer [add statements]]
             [grafter.rdf.templater :refer [graph]]
             [grafter.rdf.io :refer :all]
-            [grafter.rdf.formats :refer :all])
+            [grafter.rdf.formats :refer :all]
+            [grafter.url :refer :all])
   (:import [org.openrdf.model.impl LiteralImpl URIImpl ContextStatementImpl]))
 
 (deftest mimetype->rdf-format-test
@@ -75,3 +76,13 @@
 
         (is (= {:foo :bar} (:quad-meta ex))
             "Metadata from quads is reported in exception data")))))
+
+(deftest to-grafter-url-protocol-test
+  (testing "extends RDF Model URI"
+    (let [uri (URIImpl. "http://www.tokyo-3.com:777/ayanami?geofront=retracted")
+          grafter-url (->grafter-url uri)]
+      (are [expected actual] (= expected actual)
+                             777 (port grafter-url)
+                             "www.tokyo-3.com" (host grafter-url)
+                             "http" (scheme grafter-url)
+                             ["ayanami"] (path-segments grafter-url)))))


### PR DESCRIPTION
This PR depends upon an updated grafter-url project: https://github.com/Swirrl/grafter-url/pull/3