### PR TITLE
Open/close control over read-dataset(s) with better format dispatch

### DIFF
--- a/src/tabular/grafter/tabular/csv.clj
+++ b/src/tabular/grafter/tabular/csv.clj
@@ -15,8 +15,7 @@
 
 (defmethod tab/read-datasets* :csv
   [f opts]
-  (when-let [ds (-> (tab/read-dataset* f opts)
-                    (tab/assoc-data-source-meta f))]
+  (when-let [ds (tab/mapply tab/read-dataset f opts)]
     [{"csv" ds}]))
 
 (defmethod tab/write-dataset* :csv [destination dataset {:keys [format] :as opts}]

--- a/src/tabular/grafter/tabular/excel.clj
+++ b/src/tabular/grafter/tabular/excel.clj
@@ -42,30 +42,28 @@
       (get-sheet sheet)))
 
 (defmethod tab/read-dataset* :xls
-  [filename opts]
-  (-> filename
+  [source opts]
+  (-> source
       xls/workbook-hssf
-      (read-dataset** opts)
-      (tab/assoc-data-source-meta filename)))
+      (read-dataset** opts)))
 
 (defmethod tab/read-dataset* :xlsx
-  [filename opts]
-  (-> filename
+  [source opts]
+  (-> source
       xls/workbook-xssf
-      (read-dataset** opts)
-      (tab/assoc-data-source-meta filename)))
+      (read-dataset** opts)))
 
 (defmethod tab/read-datasets* :xls
-  [filename opts]
-  (-> filename
+  [source opts]
+  (-> source
       xls/workbook-hssf
-      (sheets filename)))
+      (sheets source)))
 
 (defmethod tab/read-datasets* :xlsx
-  [filename opts]
-  (-> filename
+  [source opts]
+  (-> source
       xls/workbook-xssf
-      (sheets filename)))
+      (sheets source)))
 
 (defn write-dataset** [destination wb dataset-map]
   (with-open [output (io/writer destination)]

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -185,6 +185,12 @@
         (is-a-dataset? dataset)
         (has-metadata? dataset))))
 
+  (testing "Open a CSV via an InputStream"
+    (with-open [in-str (io/input-stream "./test/grafter/test.csv")]
+      (let [dataset (read-dataset in-str :format :csv)]
+        (is-a-dataset? dataset)
+        (has-metadata? dataset))))
+
   (testing "Open an Excel file via a URL string"
     (let [dataset (read-dataset (->file-url-string "./test/grafter/test.xls") :format :csv)]
       (testing "returns a dataset"
@@ -218,6 +224,12 @@
   (testing "Open java.io.File"
     (let [datasets (read-datasets (io/file "./test/grafter/test.xls"))]
       (testing "returns a hashmap of sheet-names to datasets"
+        (is (every? is-a-dataset? (mapcat vals datasets)))
+        (is (= '("Sheet1" "Sheet2") (mapcat keys datasets))))))
+
+  (testing "Open InputStream"
+    (with-open [in-stream (io/input-stream "./test/grafter/test.xlsx")]
+      (let [datasets (read-datasets in-stream :format :xlsx)]
         (is (every? is-a-dataset? (mapcat vals datasets)))
         (is (= '("Sheet1" "Sheet2") (mapcat keys datasets))))))
 


### PR DESCRIPTION
…format.

Change both read-dataset and read-datasets to dispatch first on the
data source type and secondly on the data format. The current approach
combines both data source type and data format in the dispatch function
and all implementations of the inner read-dataset(s)* functions dispatch
on the data format. Add new multi-methods read-dataset-source and
read-datasets-source which dispatch on the type of the data source. The
default implementations of both these functions attempt to infer the
data format from the source if it is not explicitly provided. This
inference process is defined by the DatasetFormat protocol and can be
extended. Once the format is known, the dispatch continues to the
existing read-dataset(s)* functions which dispatch based on the format.

At present all implementations of read-dataset(s)* assume the source
implements the IOFactory protocol and can be converted to a Reader or
InputStream, although this is not a requirement.