### PR TITLE
Missing columns not explained in error message

### DIFF
--- a/src/tabular/grafter/tabular.clj
+++ b/src/tabular/grafter/tabular.clj
@@ -144,6 +144,12 @@
         val
         ::not-found))))
 
+(defn- elided-col-description [coll]
+  (let [[examples more] (take 2 (partition 3 3 nil coll))
+        csv (str/join ", " examples)
+        ellision (if (not (nil? more)) " ..." nil)]
+    (str csv ellision)))
+
 (defn columns
   "Given a dataset and a sequence of column identifiers, columns
   narrows the dataset to just the supplied columns.
@@ -168,7 +174,7 @@
     (if (not (empty? selected-cols))
       (all-columns dataset selected-cols)
       (throw (IndexOutOfBoundsException. (str "The columns: "
-                                              (str/join ", " restrained-cols)
+                                              (elided-col-description cols)
                                               " are not currently defined."))))))
 
 (defn rename-columns

--- a/src/tabular/grafter/tabular.clj
+++ b/src/tabular/grafter/tabular.clj
@@ -160,11 +160,16 @@
   [dataset cols]
   (let [col-names (column-names dataset)
         max-cols (count (:column-names dataset))
-        matched-col-positions (->> (take max-cols cols)
+        restrained-cols (take max-cols cols)
+        matched-col-positions (->> restrained-cols
                                    (map (partial col-position col-names)))
         valid-positions (filterv #(not= ::not-found %) matched-col-positions)
         selected-cols (map #(nth col-names %) valid-positions)]
-    (all-columns dataset selected-cols)))
+    (if (not (empty? selected-cols))
+      (all-columns dataset selected-cols)
+      (throw (IndexOutOfBoundsException. (str "The columns: "
+                                              (str/join ", " restrained-cols)
+                                              " are not currently defined."))))))
 
 (defn rename-columns
   "Renames the columns in the dataset.  Takes either a map or a

--- a/src/tabular/grafter/tabular.clj
+++ b/src/tabular/grafter/tabular.clj
@@ -144,10 +144,14 @@
         val
         ::not-found))))
 
-(defn- elided-col-description [coll]
-  (let [[examples more] (take 2 (partition 3 3 nil coll))
+(defn- elided-col-description
+  "Print elided descriptions of columns for error messages with a sample set and
+  the rest hidden behind an elipsis, e.g. \":one, :two, :three ...\""
+  [coll]
+  (let [[examples more] (take 2 (partition-all 3 coll))
         csv (str/join ", " examples)
-        ellision (if (not (nil? more)) " ..." nil)]
+        ellision (when (seq more)
+                   " ...")]
     (str csv ellision)))
 
 (defn columns
@@ -171,7 +175,7 @@
                                    (map (partial col-position col-names)))
         valid-positions (filterv #(not= ::not-found %) matched-col-positions)
         selected-cols (map #(nth col-names %) valid-positions)]
-    (if (not (empty? selected-cols))
+    (if (seq selected-cols)
       (all-columns dataset selected-cols)
       (throw (IndexOutOfBoundsException. (str "The columns: "
                                               (elided-col-description cols)

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -284,7 +284,28 @@
                                  ["a" "b" "d" "c"])]
           (is (= expected-dataset
                  (columns test-data [:a :b :d :c]))
-              "should return dataset containing the cols :a :b :d :c"))))
+              "should return dataset containing the cols :a :b :d :c")))
+
+      (testing "Missing keys"
+        (testing "when at least one key is found (even though rest of key range is missing)"
+          (is (columns test-data (range -3 2))
+              expected-dataset))
+
+        (testing "when no keys are found"
+          (testing "with a range"
+            (is (thrown-with-msg? IndexOutOfBoundsException
+                                  #"The columns: 11, 12 are not currently defined"
+                                  (columns test-data (range 11 13)))))
+
+          (testing "with an infinite range"
+            (is (thrown-with-msg? IndexOutOfBoundsException
+                                  #"The columns: 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 are not currently defined"
+                                  (columns test-data (iterate inc 11)))))
+
+          (testing "with keywords"
+            (is (thrown-with-msg? IndexOutOfBoundsException
+                                  #"The columns: :k, :l are not currently defined"
+                                  (columns test-data [:k :l]))))))))
 
     (testing "preserves metadata"
       (let [md {:foo :bar}
@@ -315,7 +336,7 @@
         (is (= expected-dataset result))
         ;; Columns crops the supplied sequence to the data.
         ;; This means duplicate columns may sneak in.
-        (is (= expected-dataset (columns test-dataset ["a" "a" "b"])))))))
+        (is (= expected-dataset (columns test-dataset ["a" "a" "b"]))))))
 
 (deftest rows-tests
   (let [test-data (test-dataset 10 2)]

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -253,7 +253,6 @@
            :not-found "z"
            :not-found :z))))
 
-
 (deftest columns-tests
   (testing "columns"
     (let [expected-dataset (test-dataset 5 2)
@@ -299,8 +298,8 @@
 
           (testing "with an infinite range"
             (is (thrown-with-msg? IndexOutOfBoundsException
-                                  #"The columns: 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 are not currently defined"
-                                  (columns test-data (iterate inc 11)))))
+                                  #"The columns: 13, 14, 15 ... are not currently defined"
+                                  (columns test-data (iterate inc 13)))))
 
           (testing "with keywords"
             (is (thrown-with-msg? IndexOutOfBoundsException

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -255,9 +255,9 @@
 
 
 (deftest columns-tests
-  (let [expected-dataset (test-dataset 5 2)
-        test-data (test-dataset 5 10)]
-    (testing "columns"
+  (testing "columns"
+    (let [expected-dataset (test-dataset 5 2)
+          test-data (test-dataset 5 10)]
       (testing "Narrows by string names"
         (is (= expected-dataset
                (columns test-data ["a" "b"]))  "Should select just columns a and b"))
@@ -278,46 +278,44 @@
                      (columns test-data (range 10 100)))
             "Raises an exception if columns when paired with data are not actually column headings."))
 
-      (testing "preserves metadata"
-        (let [md {:foo :bar}
-              ds (with-meta (make-dataset [[1 2 3]]) md)]
-          (is (= md
-                 (meta (columns ds [0]))))))
-
-      (testing "still returns a dataset even with only one row"
-        (let [test-data (make-dataset [["Doc Brown" "Einstein"]] ["Owner" "Dog"])
-              result (columns test-data ["Owner" "Dog"])]
-          (is (is-a-dataset? result))
-
-          (is (= test-data result))))
-
       (testing "Returns all columns from unordered sequence"
         (let [expected-dataset (assoc (test-dataset 5 4)
-                                      :column-names
-                                      ["a" "b" "d" "c"])]
+                                 :column-names
+                                 ["a" "b" "d" "c"])]
           (is (= expected-dataset
                  (columns test-data [:a :b :d :c]))
-              "should return dataset containing the cols :a :b :d :c")))
+              "should return dataset containing the cols :a :b :d :c"))))
 
-      (testing "Duplicate columns in the selection leads to duplicated column-names"
-        ;; NOTE that these behaviour's aren't really desirable - but its
-        ;; hard to prevent without using only finite sequences for
-        ;; selection.
-        ;;
-        ;; These tests are primarily to document this behaviour - even
-        ;; though it can be undesirable.
-        (let [expected-dataset (make-dataset [[0 0] [1 1]]
-                                             ["a" "a"])
-              test-dataset (test-dataset 2 2)
+    (testing "preserves metadata"
+      (let [md {:foo :bar}
+            ds (with-meta (make-dataset [[1 2 3]]) md)]
+        (is (= md
+               (meta (columns ds [0]))))))
 
-              result (columns test-dataset ["a" "a"])]
-          (is (= ["a" "a"] (column-names result)))
-          (is (= expected-dataset result))
-          ;; Columns crops the supplied sequence to the data.
-          ;; This means duplicate columns may sneak in.
-          (is (= expected-dataset (columns test-dataset ["a" "a" "b"]))))))))
+    (testing "still returns a dataset even with only one row"
+      (let [test-data (make-dataset [["Doc Brown" "Einstein"]] ["Owner" "Dog"])
+            result (columns test-data ["Owner" "Dog"])]
+        (is (is-a-dataset? result))
 
+        (is (= test-data result))))
 
+    (testing "Duplicate columns in the selection leads to duplicated column-names"
+      ;; NOTE that these behaviour's aren't really desirable - but its
+      ;; hard to prevent without using only finite sequences for
+      ;; selection.
+      ;;
+      ;; These tests are primarily to document this behaviour - even
+      ;; though it can be undesirable.
+      (let [expected-dataset (make-dataset [[0 0] [1 1]]
+                                           ["a" "a"])
+            test-dataset (test-dataset 2 2)
+
+            result (columns test-dataset ["a" "a"])]
+        (is (= ["a" "a"] (column-names result)))
+        (is (= expected-dataset result))
+        ;; Columns crops the supplied sequence to the data.
+        ;; This means duplicate columns may sneak in.
+        (is (= expected-dataset (columns test-dataset ["a" "a" "b"])))))))
 
 (deftest rows-tests
   (let [test-data (test-dataset 10 2)]


### PR DESCRIPTION
If `columns` can't find the fields you specify then it raises an error with the message:

    The columns:  are not currently defined.

This is because the error is raised in `all-columns` by which time it doesn't know the names of the columns that couldn't be found.

This patch raises the error sooner. I've used a little function to elide potentially infinite lists of columns so the error presents no more than 3 examples.

Note that lot's of unrelated lines were changed in #6973a71 - this was just to move only those tests that use the var in the binding into that closure.