### PR TITLE
Meta holding head

### DIFF
--- a/src/tabular/grafter/tabular.clj
+++ b/src/tabular/grafter/tabular.clj
@@ -138,7 +138,7 @@
   [dataset row-numbers]
   (let [original-meta (meta dataset)
         original-columns (column-names dataset)
-        rows (indexed (inc/to-list dataset))
+        rows (indexed (tabc/to-list dataset))
         filtered-rows (select-indexed rows row-numbers)]
 
     (-> (make-dataset filtered-rows
@@ -205,13 +205,13 @@
              (ifn? col-map-or-fn))]}
 
   (if (map? col-map-or-fn)
-    (inc/rename-cols col-map-or-fn dataset)
+    (rename-columns dataset (fn [col] (col-map-or-fn col col)))
     (let [original-meta (meta dataset)
           old-key->new-key (partial map-keys col-map-or-fn)
           new-columns (map col-map-or-fn
                            (column-names dataset))]
 
-      (-> (make-dataset (inc/to-list dataset)
+      (-> (make-dataset (tabc/to-list dataset)
                         new-columns)
           (with-meta original-meta)))))
 


### PR DESCRIPTION
Several functions from grafter.tabular and incanter.core/to-list hold
onto the head by referencing the original dataset (to get the meta data
and/ or column-names) after lots of processing work has been undertaken.

Since the references never went out of scope the the rows couldn't be
garbage collecting even after they had already been transformed in the
pipeline.

This PR provides changes to bind these values earlier so each row may be
released once it has been processed. This massively reduces the amount
of memory required.

A similar change to the graph-fn macro is also required (but not provided
here). 