### PR TITLE
User grafter/excel-clj which coerces numbers based on DataFormat string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,12 +9,10 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.openrdf.sesame/sesame-runtime "2.8.9"]
                  [org.clojure/tools.logging "0.3.1"]
-
                  [grafter/url "0.2.1"]
-
                  [commons-logging "1.2"] ;; Shouldn't need this, but somehow excluded and required by SPARQLRepository
                  [org.clojure/data.csv "0.1.3"]
-                 [com.outpace/clj-excel "0.0.9" :exclusions [commons-codec]]
+                 [grafter/clj-excel "0.0.9-SNAPSHOT" :exclusions [commons-codec]]
                  [me.raynes/fs "1.4.6"]
                  [potemkin "0.4.1"]
                  [incanter/incanter-core "1.5.7" :exclusions [net.sf.opencsv/opencsv commons-codec]]

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [grafter/url "0.2.1"]
                  [commons-logging "1.2"] ;; Shouldn't need this, but somehow excluded and required by SPARQLRepository
                  [org.clojure/data.csv "0.1.3"]
-                 [grafter/clj-excel "0.0.9-SNAPSHOT" :exclusions [commons-codec]]
+                 [grafter/clj-excel "0.0.9" :exclusions [commons-codec]]
                  [me.raynes/fs "1.4.6"]
                  [potemkin "0.4.1"]
                  [incanter/incanter-core "1.5.7" :exclusions [net.sf.opencsv/opencsv commons-codec]]

--- a/test/grafter/tabular_test.clj
+++ b/test/grafter/tabular_test.clj
@@ -110,7 +110,7 @@
                    ["4" "5" "6"]])
 
 (def raw-excel-data [["one" "two" "three"]
-                     [1.0 2.0 3.0]])
+                     [1 2 3]])
 
 (def csv-sheet (make-dataset raw-csv-data move-first-row-to-header))
 
@@ -167,6 +167,7 @@
     (let [dataset (read-dataset "./test/grafter/test.xlsx")]
       (testing "returns a dataset"
         (is-a-dataset? dataset)
+        (is-first-sheet? dataset)
         (has-metadata? dataset))))
 
   (testing "Open the second sheet of an XLS file"


### PR DESCRIPTION
Changed dependency to grafter/clj-excel.

Note that the `read-dataset` test now expects the integer values that you see in the excel spreadsheet.