### PR TITLE
Allow pipelines to declare the write operations they support.

### DIFF
--- a/src/pipeline/grafter/pipeline.clj
+++ b/src/pipeline/grafter/pipeline.clj
@@ -81,17 +81,6 @@
                                                                                    :sym   sym}))))
    nil))
 
-(defn wat [& {:keys [foo bar] :or {foo 0 bar 0} :as m}]
-  (println "foo: " foo ", bar: " bar)
-  (println "M: " m))
-
-(defn hello [& {:keys [salutation name]
-                :or {salutation "Hello"
-                     name "World"}
-                :as m}]
-  (println "M: " m)
-  (str salutation " " name))
-
 (defn ^:no-doc all-declared-pipelines
   "List all the declared pipelines"
   ([] (all-declared-pipelines nil))

--- a/src/pipeline/grafter/pipeline/types.clj
+++ b/src/pipeline/grafter/pipeline/types.clj
@@ -258,4 +258,4 @@
       :args args
       :type pipeline-type
       :declared-args arg-list
-      :operations supported-operations}))
+      :supported-operations supported-operations}))

--- a/src/pipeline/grafter/pipeline/types.clj
+++ b/src/pipeline/grafter/pipeline/types.clj
@@ -222,17 +222,14 @@
              arg-type-syms
              correlated-docs)))))
 
-(defn- get-supported-pipeline-operations [{:keys [supported-operations]}]
-  (if (some? supported-operations)
-    (let [ops (set supported-operations)
-          valid-operations #{:append :delete}
-          invalid-operations (set/difference ops valid-operations)]
-      (if (empty? invalid-operations)
-        ops
-        (throw (IllegalArgumentException. (str "Invalid supported operations for pipeline: "
-                                               (str/join ", " invalid-operations)
-                                               ". Valid operations are: " (str/join ", " valid-operations))))))
-    #{:append}))
+(defn- validate-supported-pipeline-operations! [supported-operations]
+  (let [ops (set supported-operations)
+        valid-operations #{:append :delete}
+        invalid-operations (set/difference ops valid-operations)]
+    (when-not (empty? invalid-operations)
+      (throw (IllegalArgumentException. (str "Invalid supported operations for pipeline: "
+                                             (str/join ", " invalid-operations)
+                                             ". Valid operations are: " (str/join ", " valid-operations)))))))
 
 ;;Var -> [Symbol] -> Metadata -> PipelineDef
 (defn ^:no-doc create-pipeline-declaration
@@ -242,19 +239,20 @@
   pipeline. The metadata map must contain a key-value pair for each
   named parameter in the pipeline function argument list. The value
   corresponding to each key in the metadata map is expected to be a
-  String describing the parameter. The metadata map can also contain
+  String describing the parameter. The opts map can contain
   an optional :supported-operations key associated to a collection
   containing :append and/or :delete. These operations indicate whether
   the data returned from the pipeline can be appended to or deleted
   from the destination."
-  [sym type-list metadata]
+  [sym type-list metadata opts]
   (let [def-var (resolve-var *ns* sym)
         def-meta (meta def-var)
         arg-list (first (:arglists def-meta))
         {:keys [arg-types return-type]} (parse-type-list type-list)
         pipeline-type (pipeline-type-from-return-type-sym return-type)
-        supported-operations (get-supported-pipeline-operations metadata)
-        args (resolve-pipeline-arg-descriptors arg-list arg-types (dissoc metadata :supported-operations))]
+        args (resolve-pipeline-arg-descriptors arg-list arg-types metadata)
+        supported-operations (:supported-operations opts #{:append})]
+    (validate-supported-pipeline-operations! supported-operations)
      {:var def-var
       :doc (or (:doc def-meta) "")
       :args args

--- a/test/grafter/pipeline_test.clj
+++ b/test/grafter/pipeline_test.clj
@@ -29,7 +29,8 @@
                                :doc s/Str
                                :args [{:name s/Symbol :class java.lang.Class :doc s/Str (s/optional-key :meta) {s/Keyword s/Any}}]
                                :type (s/either (s/eq :graft) (s/eq :pipe)) ;; one day maybe also :validation and a fallback of :function
-                               :declared-args [s/Symbol]}
+                               :declared-args [s/Symbol]
+                               :operations #{(s/enum :append :delete)}}
                      })
 
 (deftest declare-pipeline-test
@@ -90,18 +91,12 @@
     'grafter.pipeline-test/quads-pipeline
     'grafter.pipeline-test/seq-quad-pipeline))
 
-
-
-
-
-(defn uuid-pipeline-test [uuid]
-  )
+(defn uuid-pipeline-test [uuid])
 
 (declare-pipeline uuid-pipeline-test
   "Test pipeline for map objects"
   [UUID -> (Seq Statement)]
   {uuid "A UUID"})
-
 
 (defn url-pipeline-test [url]
   [])
@@ -168,3 +163,20 @@
                                                    "cabec818-df6a-4c27-b445-117163e70227"
                                                    ":foo"
                                                    "2015"]))))
+
+(defn delete-only-pipeline [uri])
+(defn append-only-pipeline [uri])
+
+(declare-pipeline delete-only-pipeline
+                  [URI -> (Seq Statement)]
+                  {:supported-operations #{:delete}
+                   uri "URI"})
+
+(declare-pipeline append-only-pipeline
+                  [URI -> (Seq Statement)]
+                  {uri "URI"})
+
+(deftest supported-operations-test
+  (are [pipeline-sym expected] (= expected (get-in @exported-pipelines [pipeline-sym :operations]))
+                               'grafter.pipeline-test/delete-only-pipeline #{:delete}
+                               'grafter.pipeline-test/append-only-pipeline #{:append}))

--- a/test/grafter/pipeline_test.clj
+++ b/test/grafter/pipeline_test.clj
@@ -169,8 +169,8 @@
 
 (declare-pipeline delete-only-pipeline
                   [URI -> (Seq Statement)]
-                  {:supported-operations #{:delete}
-                   uri "URI"})
+                  {uri "URI"}
+                  :supported-operations #{:delete})
 
 (declare-pipeline append-only-pipeline
                   [URI -> (Seq Statement)]

--- a/test/grafter/pipeline_test.clj
+++ b/test/grafter/pipeline_test.clj
@@ -30,7 +30,7 @@
                                :args [{:name s/Symbol :class java.lang.Class :doc s/Str (s/optional-key :meta) {s/Keyword s/Any}}]
                                :type (s/either (s/eq :graft) (s/eq :pipe)) ;; one day maybe also :validation and a fallback of :function
                                :declared-args [s/Symbol]
-                               :operations #{(s/enum :append :delete)}}
+                               :supported-operations #{(s/enum :append :delete)}}
                      })
 
 (deftest declare-pipeline-test
@@ -177,6 +177,6 @@
                   {uri "URI"})
 
 (deftest supported-operations-test
-  (are [pipeline-sym expected] (= expected (get-in @exported-pipelines [pipeline-sym :operations]))
+  (are [pipeline-sym expected] (= expected (get-in @exported-pipelines [pipeline-sym :supported-operations]))
                                'grafter.pipeline-test/delete-only-pipeline #{:delete}
                                'grafter.pipeline-test/append-only-pipeline #{:append}))


### PR DESCRIPTION
Allow an optional :supported-operations key in the metadata map
within pipeline declarations. The associated value should be a
collection containing :append and/or :delete which define the
permitted operations when applying the pipeline results to the
destination.