### PR TITLE
Add function to add statements to a repository in batches.

### DIFF
--- a/test/grafter/rdf_test.clj
+++ b/test/grafter/rdf_test.clj
@@ -37,7 +37,17 @@
     ([{:keys [repo batch-sizes] :as this} graph triples]
      (swap! batch-sizes conj (count triples))
      (proto/add repo graph triples)
-     this)))
+     this))
+
+  proto/ITripleDeleteable
+  (proto/delete
+    ([{:keys [repo batch-sizes]} quads]
+      (swap! batch-sizes conj (count quads))
+      (proto/delete repo quads))
+
+    ([{:keys [repo batch-sizes]} graph triples]
+      (swap! batch-sizes conj (count triples))
+      (proto/delete repo graph triples))))
 
 (deftest add-batched-test
   (let [triples (map (fn [i] (->Triple (URI. (str "http://subject" i)) (URI. (str "http://predicate" i)) (URI. (str "http://object" i)))) (range 1 11))
@@ -69,3 +79,41 @@
         (add-batched recording-repo graph triples 5)
         (is (= (set expected-quads) (set (statements repo))))
         (is (= [5 5] @batch-sizes))))))
+
+(defn- triple->quad [graph triple]
+  (assoc triple :c graph))
+
+(deftest delete-batched-test
+  (let [initial-triples (map (fn [i] (->Triple (URI. (str "http://subject" i)) (URI. (str "http://predicate" i)) (URI. (str "http://object" i)))) (range 1 11))
+        [to-keep to-delete] (split-at 4 initial-triples)
+        graph (URI. "http://test-graph")
+        make-quads (fn [triples] (map #(triple->quad graph %) triples))]
+    (testing "Deletes all triples"
+      (let [repo (repo/repo)]
+        (add repo initial-triples)
+        (delete-batched repo to-delete)
+        (is (= (set to-keep) (set (statements repo))))))
+
+    (testing "Deletes all triples with graph"
+      (let [repo (repo/repo)]
+        (add repo (make-quads initial-triples))
+        (delete-batched repo graph to-delete)
+        (is (= (set (make-quads to-keep)) (set (statements repo))))))
+
+    (testing "Deletes all triples in sized batches"
+      (let [repo (repo/repo)
+            batch-sizes (atom [])
+            recording-repo (->BatchSizeRecordingRepository repo batch-sizes)]
+        (add repo initial-triples)
+        (delete-batched recording-repo to-delete 4)
+        (is (= (set to-keep) (set (statements repo))))
+        (is (= [4 2] @batch-sizes))))
+
+    (testing "Deletes all triples with graph in sized batches"
+      (let [repo (repo/repo)
+            batch-sizes (atom [])
+            recording-repo (->BatchSizeRecordingRepository repo batch-sizes)]
+        (add repo (make-quads initial-triples))
+        (delete-batched recording-repo graph to-delete 4)
+        (is (= (set (make-quads to-keep)) (set (statements repo))))
+        (is (= [4 2] @batch-sizes))))))


### PR DESCRIPTION
Add grafter.rdf/add-batched function which splits an input sequence of
statements into batches before adding them through grafter.rdf/add.