### PR TITLE
Rdf4j

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,13 +8,13 @@
 
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
                  [org.eclipse.rdf4j/rdf4j-runtime "2.2.2"]
-                 [org.clojure/tools.logging "0.3.1"]
+                 [org.clojure/tools.logging "0.4.0"]
                  [grafter/url "0.2.5"]
-                 [grafter/vocabularies "0.2.0"]
+                 [grafter/vocabularies "0.2.2"]
 
                  [me.raynes/fs "1.4.6"]
-                 [potemkin "0.4.3"]
-                 [com.novemberain/pantomime "2.8.0"]] ;; mimetypes
+                 [potemkin "0.4.4"]
+                 [com.novemberain/pantomime "2.9.0"]] ;; mimetypes
 
 
   :codox {:defaults {:doc "FIXME: write docs"
@@ -38,8 +38,8 @@
 
              :dev {:plugins [[codox "0.8.10"]]
 
-                   :dependencies [[org.slf4j/slf4j-simple "1.7.21"]
-                                  [prismatic/schema "1.1.3"]
+                   :dependencies [[org.slf4j/slf4j-simple "1.7.25"]
+                                  [prismatic/schema "1.1.7"]
                                   [criterium "0.4.4"]]
 
                    :resource-paths ["dev/resources"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject grafter/grafter "0.9.0-SNAPSHOT"
+(defproject grafter/grafter "0.10.0-SNAPSHOT"
   :description "Tools for the hard graft of linked data processing"
   :url "http://grafter.org/"
   :license {:name "Eclipse Public License - v1.0"

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
 
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
                  [org.openrdf.sesame/sesame-runtime "2.8.9"]
+                 [org.eclipse.rdf4j/rdf4j-runtime "2.2.2"]
                  [org.clojure/tools.logging "0.3.1"]
                  [grafter/url "0.2.5"]
                  [grafter/vocabularies "0.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :deploy-repositories [["releases" :clojars]]
 
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
-                 [org.openrdf.sesame/sesame-runtime "2.8.9"]
+                 
                  [org.eclipse.rdf4j/rdf4j-runtime "2.2.2"]
                  [org.clojure/tools.logging "0.3.1"]
                  [grafter/url "0.2.5"]

--- a/project.clj
+++ b/project.clj
@@ -7,13 +7,11 @@
   :deploy-repositories [["releases" :clojars]]
 
   :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
-                 
                  [org.eclipse.rdf4j/rdf4j-runtime "2.2.2"]
                  [org.clojure/tools.logging "0.3.1"]
                  [grafter/url "0.2.5"]
                  [grafter/vocabularies "0.2.0"]
 
-                 [commons-logging "1.2"] ;; Shouldn't need this, but somehow excluded and required by SPARQLRepository
                  [me.raynes/fs "1.4.6"]
                  [potemkin "0.4.3"]
                  [com.novemberain/pantomime "2.8.0"]] ;; mimetypes

--- a/src/grafter/rdf.clj
+++ b/src/grafter/rdf.clj
@@ -9,12 +9,11 @@
 (require '[grafter.rdf.io])
 
 (import-vars
- [grafter.rdf.io
-  language
-  literal]
  [grafter.rdf.protocols
   ->Quad
   ->Triple
+  language
+  literal
   triple?])
 
 (defn subject

--- a/src/grafter/rdf/formats.clj
+++ b/src/grafter/rdf/formats.clj
@@ -63,7 +63,7 @@
   "Given a filename we attempt to return an appropriate RDFFormat
   object based on the files extension."
   [fname]
-  (Rio/getParserFormatForFileName (str fname)))
+  (.orElse (Rio/getParserFormatForFileName (str fname)) nil))
 
 (defn url->rdf-format
   "Parse a URL for the file extension of its last path segment,

--- a/src/grafter/rdf/formats.clj
+++ b/src/grafter/rdf/formats.clj
@@ -3,17 +3,17 @@
   (:require [clojure.string :as string]
             [grafter.url :as url]
             [clojure.string :as str])
-  (:import [org.openrdf.rio RDFFormat RDFParser RDFParserFactory Rio]
-           org.openrdf.rio.binary.BinaryRDFParserFactory
-           org.openrdf.rio.jsonld.JSONLDParserFactory
-           org.openrdf.rio.n3.N3ParserFactory
-           org.openrdf.rio.nquads.NQuadsParserFactory
-           org.openrdf.rio.ntriples.NTriplesParserFactory
-           org.openrdf.rio.rdfjson.RDFJSONParserFactory
-           org.openrdf.rio.rdfxml.RDFXMLParserFactory
-           org.openrdf.rio.trig.TriGParserFactory
-           org.openrdf.rio.trix.TriXParserFactory
-           org.openrdf.rio.turtle.TurtleParserFactory))
+  (:import [org.eclipse.rdf4j.rio RDFFormat RDFParser RDFParserFactory Rio]
+           org.eclipse.rdf4j.rio.binary.BinaryRDFParserFactory
+           org.eclipse.rdf4j.rio.jsonld.JSONLDParserFactory
+           org.eclipse.rdf4j.rio.n3.N3ParserFactory
+           org.eclipse.rdf4j.rio.nquads.NQuadsParserFactory
+           org.eclipse.rdf4j.rio.ntriples.NTriplesParserFactory
+           org.eclipse.rdf4j.rio.rdfjson.RDFJSONParserFactory
+           org.eclipse.rdf4j.rio.rdfxml.RDFXMLParserFactory
+           org.eclipse.rdf4j.rio.trig.TriGParserFactory
+           org.eclipse.rdf4j.rio.trix.TriXParserFactory
+           org.eclipse.rdf4j.rio.turtle.TurtleParserFactory))
 
 (defmulti mimetype->rdf-format
   "Extensible multimethod that accepts a mime-type string and returns
@@ -80,7 +80,7 @@
 (defmethod ->rdf-format java.net.URL [f]
   (url->rdf-format f))
 
-(defmethod ->rdf-format org.openrdf.model.URI [f]
+(defmethod ->rdf-format org.eclipse.rdf4j.model.URI [f]
   (url->rdf-format f))
 
 (defmacro def-format

--- a/src/grafter/rdf/io.clj
+++ b/src/grafter/rdf/io.clj
@@ -15,9 +15,9 @@
            [java.net MalformedURLException URL]
            java.util.GregorianCalendar
            javax.xml.datatype.DatatypeFactory
-           [org.openrdf.model BNode Literal Resource Statement URI Value]
-           [org.openrdf.model.impl BNodeImpl BooleanLiteralImpl CalendarLiteralImpl ContextStatementImpl IntegerLiteralImpl LiteralImpl NumericLiteralImpl StatementImpl URIImpl]
-           [org.openrdf.rio RDFFormat RDFHandler RDFWriter Rio]))
+           [org.eclipse.rdf4j.model BNode Literal Resource Statement URI Value]
+           [org.eclipse.rdf4j.model.impl SimpleValueFactory BNodeImpl BooleanLiteralImpl CalendarLiteral ContextStatementImpl IntegerLiteral LiteralImpl NumericLiteral StatementImpl URIImpl]
+           [org.eclipse.rdf4j.rio RDFFormat RDFHandler RDFWriter Rio]))
 
 (extend-type Statement
   ;; Extend our IStatement protocol to Sesame's Statements for convenience.
@@ -123,63 +123,63 @@
 
   java.lang.Byte
   (->sesame-rdf-type [this]
-    (NumericLiteralImpl. this (URIImpl. "http://www.w3.org/2001/XMLSchema#byte")))
+    (.. (SimpleValueFactory/getInstance) (createLiteral this)))
 
   (sesame-rdf-type->type [this]
     this)
 
   java.lang.Short
   (->sesame-rdf-type [this]
-    (NumericLiteralImpl. this (URIImpl. "http://www.w3.org/2001/XMLSchema#short")))
+    (.. (SimpleValueFactory/getInstance) (createLiteral this)))
 
   (sesame-rdf-type->type [this]
     this)
 
   java.math.BigDecimal
   (->sesame-rdf-type [this]
-    (NumericLiteralImpl. this (URIImpl. "http://www.w3.org/2001/XMLSchema#decimal")))
+    (.. (SimpleValueFactory/getInstance) (createLiteral this)))
 
   (sesame-rdf-type->type [this]
     this)
 
   java.lang.Double
   (->sesame-rdf-type [this]
-    (NumericLiteralImpl. this))
+    (.. (SimpleValueFactory/getInstance) (createLiteral this)))
 
   (sesame-rdf-type->type [this]
     this)
 
   java.lang.Float
   (->sesame-rdf-type [this]
-    (NumericLiteralImpl. this))
+    (.. (SimpleValueFactory/getInstance) (createLiteral this)))
 
   (sesame-rdf-type->type [this]
     this)
 
   java.lang.Integer
   (->sesame-rdf-type [this]
-    (NumericLiteralImpl. this))
+    (.. (SimpleValueFactory/getInstance) (createLiteral (int this))))
 
   (sesame-rdf-type->type [this]
     this)
 
   java.math.BigInteger
   (->sesame-rdf-type [this]
-    (NumericLiteralImpl. this (URIImpl. "http://www.w3.org/2001/XMLSchema#integer")))
+    (.. (SimpleValueFactory/getInstance) (createLiteral this)))
 
   (sesame-rdf-type->type [this]
     this)
 
   java.lang.Long
   (->sesame-rdf-type [this]
-    (NumericLiteralImpl. (long this)))
+    (.. (SimpleValueFactory/getInstance) (createLiteral (long this))))
 
   (sesame-rdf-type->type [this]
     this)
 
   clojure.lang.BigInt
   (->sesame-rdf-type [this]
-    (IntegerLiteralImpl. (BigInteger. (str this))))
+    (.. (SimpleValueFactory/getInstance) (createLiteral  (BigInteger. (str this)))))
 
   (sesame-rdf-type->type [this]
     this))
@@ -213,7 +213,7 @@
 
   java.lang.Boolean
   (->sesame-rdf-type [this]
-    (BooleanLiteralImpl. this))
+    (.. (SimpleValueFactory/getInstance) (createLiteral this)))
 
   (sesame-rdf-type->type [this]
     this)
@@ -287,9 +287,7 @@
   (->sesame-rdf-type [this]
     (let [cal (doto (GregorianCalendar.)
                 (.setTime this))]
-      (-> (DatatypeFactory/newInstance)
-          (.newXMLGregorianCalendar cal)
-          CalendarLiteralImpl.)))
+      (.. (SimpleValueFactory/getInstance) (createLiteral this))))
 
   clojure.lang.Keyword
   (->sesame-rdf-type [this]
@@ -322,7 +320,7 @@
 ;; Extend IURIable protocol to sesame URI's.
 (extend-protocol IURIable
 
-  org.openrdf.model.URI
+  org.eclipse.rdf4j.model.URI
 
   (->java-uri [this]
     (java.net.URI. (.stringValue this))))
@@ -587,9 +585,9 @@
   (->sesame-uri [this] (URIImpl. (str this)))
   java.net.URI
   (->sesame-uri [this] (URIImpl. (str this)))
-  org.openrdf.model.URI
+  org.eclipse.rdf4j.model.URI
   (->sesame-uri [this] this)
   GrafterURL
   (->sesame-uri [this] (URIImpl. (str this)))
-  org.openrdf.model.Graph
+  org.eclipse.rdf4j.model.Graph
   (->sesame-uri [this] (URIImpl. (str this))))

--- a/src/grafter/rdf/protocols.clj
+++ b/src/grafter/rdf/protocols.clj
@@ -4,7 +4,7 @@
             [grafter.url :refer [->java-uri]])
   (:import [java.net URI]
            [java.util Date]
-           [org.openrdf.model Literal]))
+           [org.eclipse.rdf4j.model Literal]))
 
 (defprotocol IStatement
   "An RDF triple or quad"

--- a/src/grafter/rdf/protocols.clj
+++ b/src/grafter/rdf/protocols.clj
@@ -151,7 +151,7 @@
 (extend-type Literal
   IRDFString
   (lang [this]
-    (keyword (.getLanguage this)))
+    (keyword (.orElse (.getLanguage this) nil)))
 
   IRawValue
   (raw-value [this]

--- a/src/grafter/rdf/repository.clj
+++ b/src/grafter/rdf/repository.clj
@@ -14,26 +14,25 @@
            (java.net MalformedURLException URL)
            (java.util GregorianCalendar)
            (javax.xml.datatype DatatypeFactory)
-           (org.openrdf.model BNode Literal Resource Statement URI
+           (org.eclipse.rdf4j.model BNode Literal Resource Statement URI
                               Value Graph)
-           (org.openrdf.query BooleanQuery GraphQuery QueryLanguage
+           (org.eclipse.rdf4j.query BooleanQuery GraphQuery QueryLanguage
                               Query TupleQuery Update BindingSet)
-           (org.openrdf.model.impl BNodeImpl BooleanLiteralImpl
-                                   CalendarLiteralImpl
-                                   ContextStatementImpl
-                                   IntegerLiteralImpl LiteralImpl
-                                   NumericLiteralImpl StatementImpl
+           (org.eclipse.rdf4j.model.impl BNodeImpl BooleanLiteralImpl
+                                         ContextStatementImpl
+                                   IntegerLiteral LiteralImpl
+                                   NumericLiteral StatementImpl
                                    URIImpl)
-           (org.openrdf.query.impl DatasetImpl)
-           (org.openrdf.repository Repository RepositoryConnection)
-           (org.openrdf.repository.http HTTPRepository)
-           (org.openrdf.repository.sail SailRepository)
-           (org.openrdf.repository.sparql SPARQLRepository)
-           (org.openrdf.sail Sail)
-           (org.openrdf.sail.memory MemoryStore)
-           (org.openrdf.sail.nativerdf NativeStore)
-           (info.aduna.iteration CloseableIteration)
-           (org.openrdf.sail.inferencer.fc ForwardChainingRDFSInferencer
+           (org.eclipse.rdf4j.query.impl DatasetImpl)
+           (org.eclipse.rdf4j.repository Repository RepositoryConnection)
+           (org.eclipse.rdf4j.repository.http HTTPRepository)
+           (org.eclipse.rdf4j.repository.sail SailRepository)
+           (org.eclipse.rdf4j.repository.sparql SPARQLRepository)
+           (org.eclipse.rdf4j.sail Sail)
+           (org.eclipse.rdf4j.sail.memory MemoryStore)
+           (org.eclipse.rdf4j.sail.nativerdf NativeStore)
+           (org.eclipse.rdf4j.common.iteration CloseableIteration)
+           (org.eclipse.rdf4j.sail.inferencer.fc ForwardChainingRDFSInferencer
                                            DirectTypeHierarchyInferencer
                                            CustomGraphQueryInferencer)))
 
@@ -41,7 +40,7 @@
   (->connection [repo] "Given a sesame repository return a connection to it.
   ->connection is designed to be used with the macro with-open"))
 
-(defn- resource-array #^"[Lorg.openrdf.model.Resource;" [& rs]
+(defn- resource-array #^"[Lorg.eclipse.rdf4j.model.Resource;" [& rs]
   (into-array Resource rs))
 
 (extend-type RepositoryConnection

--- a/src/grafter/rdf/repository/registry.clj
+++ b/src/grafter/rdf/repository/registry.clj
@@ -14,11 +14,11 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log])
   (:import [java.nio.charset Charset]
-           [org.openrdf.rio RDFParserRegistry RDFFormat]
-           [org.openrdf.query.resultio TupleQueryResultFormat BooleanQueryResultFormat
+           [org.eclipse.rdf4j.rio RDFParserRegistry RDFFormat]
+           [org.eclipse.rdf4j.query.resultio TupleQueryResultFormat BooleanQueryResultFormat
             TupleQueryResultParserRegistry
             BooleanQueryResultParserRegistry]
-           [org.openrdf.query.resultio.text.csv SPARQLResultsCSVParserFactory]))
+           [org.eclipse.rdf4j.query.resultio.text.csv SPARQLResultsCSVParserFactory]))
 
 
 (defn parser-registries
@@ -81,23 +81,23 @@
 
   (registered-parser-factories) ;; =>
 
-  {:select #{org.openrdf.query.resultio.sparqlxml.SPARQLResultsXMLParserFactory
-             org.openrdf.query.resultio.text.csv.SPARQLResultsCSVParserFactory
-             org.openrdf.query.resultio.sparqljson.SPARQLResultsJSONParserFactory
-             org.openrdf.query.resultio.text.tsv.SPARQLResultsTSVParserFactory
-             org.openrdf.query.resultio.binary.BinaryQueryResultParserFactory},
-   :construct #{org.openrdf.rio.ntriples.NTriplesParserFactory
-                org.openrdf.rio.trix.TriXParserFactory
-                org.openrdf.rio.jsonld.JSONLDParserFactory
-                org.openrdf.rio.trig.TriGParserFactory
-                org.openrdf.rio.binary.BinaryRDFParserFactory
-                org.openrdf.rio.n3.N3ParserFactory
-                org.openrdf.rio.rdfjson.RDFJSONParserFactory
-                org.openrdf.rio.rdfxml.RDFXMLParserFactory
-                org.openrdf.rio.nquads.NQuadsParserFactory},
-   :ask #{org.openrdf.query.resultio.sparqljson.SPARQLBooleanJSONParserFactory
-          org.openrdf.query.resultio.text.BooleanTextParserFactory
-          org.openrdf.query.resultio.sparqlxml.SPARQLBooleanXMLParserFactory}}
+  {:select #{org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLParserFactory
+             org.eclipse.rdf4j.query.resultio.text.csv.SPARQLResultsCSVParserFactory
+             org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONParserFactory
+             org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVParserFactory
+             org.eclipse.rdf4j.query.resultio.binary.BinaryQueryResultParserFactory},
+   :construct #{org.eclipse.rdf4j.rio.ntriples.NTriplesParserFactory
+                org.eclipse.rdf4j.rio.trix.TriXParserFactory
+                org.eclipse.rdf4j.rio.jsonld.JSONLDParserFactory
+                org.eclipse.rdf4j.rio.trig.TriGParserFactory
+                org.eclipse.rdf4j.rio.binary.BinaryRDFParserFactory
+                org.eclipse.rdf4j.rio.n3.N3ParserFactory
+                org.eclipse.rdf4j.rio.rdfjson.RDFJSONParserFactory
+                org.eclipse.rdf4j.rio.rdfxml.RDFXMLParserFactory
+                org.eclipse.rdf4j.rio.nquads.NQuadsParserFactory},
+   :ask #{org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLBooleanJSONParserFactory
+          org.eclipse.rdf4j.query.resultio.text.BooleanTextParserFactory
+          org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLBooleanXMLParserFactory}}
 
 
   ;; Once you have the datastructure above, you can adjust it as
@@ -105,7 +105,7 @@
 
   (let [updated-registries (update (registered-parser-factories)
                                    ;; Force removal of TurtleParser
-                                   :construct #(disj % org.openrdf.rio.turtle.TurtleParserFactory))]
+                                   :construct #(disj % org.eclipse.rdf4j.rio.turtle.TurtleParserFactory))]
 
     ;; reset the registered parsers
     (register-parser-factories! updated-registries))

--- a/src/grafter/rdf/sparql.clj
+++ b/src/grafter/rdf/sparql.clj
@@ -1,4 +1,6 @@
 (ns grafter.rdf.sparql
+  "Functions for executing SPARQL queries with grafter RDF
+  repositories, that support basic binding replacement etc."
   (:require [grafter.rdf :refer [statements]]
             [grafter.rdf.repository :refer [repo sparql-repo ->connection]]
             [grafter.rdf.repository :as repo]

--- a/src/grafter/rdf/sparql.clj
+++ b/src/grafter/rdf/sparql.clj
@@ -6,7 +6,7 @@
             [clojure.java.io :refer [resource]]
             [clojure.string :as str]
             [clojure.java.io :as io])
-  (:import [org.openrdf.rio.ntriples NTriplesUtil]
+  (:import [org.eclipse.rdf4j.rio.ntriples NTriplesUtil]
            [java.util.regex Pattern]))
 
 (defn- get-clause-pattern [clause-name key]

--- a/src/grafter/rdf/templater.clj
+++ b/src/grafter/rdf/templater.clj
@@ -3,8 +3,8 @@
   Data statements (triples/quads)."
   (:require [grafter.rdf :as rdf])
   (:require [grafter.rdf.protocols :refer [->Triple ->Quad]])
-  (:import [org.openrdf.rio RDFFormat]
-           [org.openrdf.model URI]))
+  (:import [org.eclipse.rdf4j.rio RDFFormat]
+           [org.eclipse.rdf4j.model URI]))
 
 (defn- valid-uri? [node]
   (let [types [java.lang.String java.net.URL java.net.URI URI]]

--- a/test/grafter/io_test.clj
+++ b/test/grafter/io_test.clj
@@ -3,7 +3,7 @@
             [grafter.rdf.protocols :refer [->Quad]]
             [grafter.rdf :refer [add statements]]
             [grafter.rdf.templater :refer [graph]]
-            [grafter.rdf.io :refer :all]
+            [grafter.rdf4j.io :refer :all]
             [grafter.url :refer :all]
             [grafter.rdf.protocols :as pr]
             [grafter.rdf.formats :as fmt]
@@ -31,7 +31,7 @@
 
 (deftest round-trip-numeric-types-test
   (are [xsd type number]
-      (is (= number (pr/raw-value (->sesame-rdf-type (sesame-rdf-type->type (LiteralImpl. number (URIImpl. xsd)))))))
+      (is (= number (pr/raw-value (->backend-type (->grafter-type (LiteralImpl. number (URIImpl. xsd)))))))
 
     "http://www.w3.org/2001/XMLSchema#byte" Byte "10"
     "http://www.w3.org/2001/XMLSchema#short" Short "10"
@@ -62,12 +62,12 @@
     "hello"        "http://www.w3.org/2001/XMLSchema#string" String))
 
 (deftest literal-test
-  (is (instance? LiteralImpl (->sesame-rdf-type (literal "2014-01-01" (java.net.URI. "http://www.w3.org/2001/XMLSchema#date"))))))
+  (is (instance? LiteralImpl (->backend-type (literal "2014-01-01" (java.net.URI. "http://www.w3.org/2001/XMLSchema#date"))))))
 
 (deftest language-string-test
   (let [bonsoir (language "Bonsoir Mademoiselle" :fr)]
     (is (= bonsoir (literal-datatype->type bonsoir)))
-    (is (= bonsoir (sesame-rdf-type->type (->sesame-rdf-type bonsoir))))))
+    (is (= bonsoir (->grafter-type (->backend-type bonsoir))))))
 
 (deftest round-trip-quad-test
   (let [quad (->Quad (->java-uri "http://example.org/test/subject")
@@ -96,6 +96,7 @@
       (with-open [rdr (java.io.StringReader. output-str)]
         (is (= quad
                (statements rdr :format :nq)))))))
+
 
 (deftest IStatement->sesame-statement-test
   (testing "IStatement->sesame-statement"

--- a/test/grafter/rdf/formats_test.clj
+++ b/test/grafter/rdf/formats_test.clj
@@ -2,7 +2,7 @@
   (:require [grafter.rdf.formats :as fmt]
             [clojure.test :refer :all]
             [clojure.java.io :as io])
-  (:import [org.openrdf.rio RDFFormat]
+  (:import [org.eclipse.rdf4j.rio RDFFormat]
            [java.net URI URL]))
 
 (deftest mimetype->rdf-format-test
@@ -25,12 +25,12 @@
          (fmt/->rdf-format "nt")
          (fmt/->rdf-format "application/n-triples")
          (fmt/->rdf-format "text/plain")
-         (fmt/->rdf-format (io/file "/tmp/foo.nt"))
-         (fmt/->rdf-format (URI. "http://foo.bar.com/tmp/foo.nt"))
-         (fmt/->rdf-format (URL. "http://foo.bar.com/tmp/foo.nt"))
-         (fmt/->rdf-format (URI. "http://foo.bar.com/tmp/foo.nt?query=string&is=ignored"))
          fmt/rdf-ntriples
          RDFFormat/NTRIPLES))
+  (is (= (fmt/->rdf-format (URI. "http://foo.bar.com/tmp/foo.nt"))
+         (fmt/->rdf-format (URL. "http://foo.bar.com/tmp/foo.nt"))
+         (fmt/->rdf-format (io/file "/tmp/foo.nt"))
+         (fmt/->rdf-format (URI. "http://foo.bar.com/tmp/foo.nt?query=string&is=ignored"))))
 
   (is (nil? (fmt/->rdf-format "/tmp/foo.nt"))
       "File path strings are not parsed for formats.  To do this provide you need to provide a File object.")

--- a/test/grafter/rdf/io_test.clj
+++ b/test/grafter/rdf/io_test.clj
@@ -9,7 +9,7 @@
             [schema.core :as s]
             [grafter.rdf.formats :as fmt]
             [clojure.java.io :as io])
-  (:import [org.openrdf.model.impl LiteralImpl URIImpl ContextStatementImpl]
+  (:import [org.eclipse.rdf4j.model.impl LiteralImpl URIImpl ContextStatementImpl]
            [java.net URI]))
 
 ;; NOTE this function is deprecated in favour of the one in formats,

--- a/test/grafter/rdf/io_test.clj
+++ b/test/grafter/rdf/io_test.clj
@@ -6,7 +6,6 @@
             [grafter.rdf.io :refer :all]
             [grafter.url :refer :all]
             [grafter.rdf.protocols :as pr]
-            [schema.core :as s]
             [grafter.rdf.formats :as fmt]
             [clojure.java.io :as io])
   (:import [org.eclipse.rdf4j.model.impl LiteralImpl URIImpl ContextStatementImpl]
@@ -129,12 +128,8 @@
                              "http" (scheme grafter-url)
                              ["ayanami"] (path-segments grafter-url)))))
 
-(def BlankObjectNode {:s URI :p URI :o s/Keyword :c (s/eq nil)})
-
-(def BlankSubjectNode {:s s/Keyword :p URI :o URI :c (s/eq nil) })
-
-
 (deftest blank-nodes-load-test
-  (let [[btriple1 btriple2] (statements (io/resource "grafter/rdf/bnodes.nt"))]
-    (is (s/validate BlankObjectNode btriple1))
-    (is (s/validate BlankSubjectNode btriple2))))
+  (testing "Blank nodes are keywords"
+    (let [[[s1 p1 o1] [s2 p2 o2]] (statements (io/resource "grafter/rdf/bnodes.nt"))]
+      (is (keyword? o1))
+      (is (keyword? s2)))))

--- a/test/grafter/rdf/protocols_test.clj
+++ b/test/grafter/rdf/protocols_test.clj
@@ -1,8 +1,8 @@
 (ns grafter.rdf.protocols-test
   (:require [clojure.test :refer :all]
             [grafter.rdf.protocols :refer :all]
-            [grafter.rdf :refer [language]]
-            [grafter.vocabularies.xsd :refer :all])
+            [grafter.vocabularies.xsd :refer :all]
+            [grafter.rdf.protocols :as pr])
   (:import [org.eclipse.rdf4j.model.impl LiteralImpl]))
 
 (def test-data [["http://a1" "http://b1" "http://c1" "http://graph1"]
@@ -25,7 +25,7 @@
 
 (deftest rdf-strings-test
   (testing "RDF Strings"
-    (let [en (language "Hello" :en)
+   (let [en (pr/language "Hello" :en)
           sesame-fr (LiteralImpl. "Bonjour" "fr")
           sesame-nolang (LiteralImpl. "Bonjour")]
       (are [expected test-val]

--- a/test/grafter/rdf/protocols_test.clj
+++ b/test/grafter/rdf/protocols_test.clj
@@ -3,7 +3,7 @@
             [grafter.rdf.protocols :refer :all]
             [grafter.rdf :refer [language]]
             [grafter.vocabularies.xsd :refer :all])
-  (:import [org.openrdf.model.impl LiteralImpl]))
+  (:import [org.eclipse.rdf4j.model.impl LiteralImpl]))
 
 (def test-data [["http://a1" "http://b1" "http://c1" "http://graph1"]
                 ["http://a2" "http://b2" "http://c2" "http://graph2"]])

--- a/test/grafter/rdf/repository_test.clj
+++ b/test/grafter/rdf/repository_test.clj
@@ -8,9 +8,9 @@
             [grafter.rdf.formats :refer :all]
             [clojure.test :refer :all]
             [grafter.rdf.repository :as repo])
-  (:import org.openrdf.model.impl.GraphImpl
-           org.openrdf.sail.memory.MemoryStore
-           org.openrdf.repository.sparql.SPARQLRepository
+  (:import org.eclipse.rdf4j.model.impl.GraphImpl
+           org.eclipse.rdf4j.sail.memory.MemoryStore
+           org.eclipse.rdf4j.repository.sparql.SPARQLRepository
            java.net.URI
            java.net.URL))
 
@@ -155,7 +155,7 @@
       (is (= 2 (count (grafter.rdf/statements conn)))))))
 
 (deftest sail-repo-test
-  (is (instance? org.openrdf.repository.Repository (sail-repo)))
+  (is (instance? org.eclipse.rdf4j.repository.Repository (sail-repo)))
   (is (= (into #{} (sail-repo))
          #{})))
 


### PR DESCRIPTION
Upgrade grafter to RDF4j in more or less the style suggested by Rich Hickey's speculation talk.

Deprecate `grafter.rdf.io` and introduce `grafter.rdf4j.io` as its replacement.

The only complication for legacy users of grafter.rdf.io is that the transitive dependency on sesame in the legacy namespace has also been replaced by RDF4j.  This means that if you depend directly on sesame rather than RDF4j and RDF4j you will need to make some changes, as described in the [sesame to RDF4j migration guide](http://docs.rdf4j.org/migration/).  These changes are largely also through accretion and bug fixes.

Within this new namespace `grafter.rdf4j.io` some functions have been given new names (though the old names should work in `grafter.rdf.io`) the new name mappings are:

- `grafter.rdf.io/rdf-serializer` renamed to `grafter.rdf4j.io/rdf-writer`
- `grafter.rdf.io/literal-datatype->type` renamed to `grafter.rdf4j.io/backend-literal->grafter-type`
- `grafter.rdf.io/->sesame-rdf-type` renamed to `grafter.rdf4j.io/->backend-type`
- `grafter.rdf.io/sesame-rdf-type->type` renamed to `grafter.rdf.protocols/->grafter-type`

Additionally some functions such as `literal` and `language` are no longer in `grafter.rdf4j.io` but have been added to `grafter.rdf.protocols`.
