### PR TITLE
Add grafter.rdf.sparql/paged-query

### DIFF
--- a/dev/resources/grafter/rdf/sparql/select-spog-paginated.sparql
+++ b/dev/resources/grafter/rdf/sparql/select-spog-paginated.sparql
@@ -1,0 +1,9 @@
+SELECT * WHERE {
+  {
+    SELECT DISTINCT ?s WHERE {
+      ?s ?p ?o
+    } ORDER BY ?s LIMIT ?batchLimit OFFSET ?batchOffset
+  }
+
+  ?s ?p ?o .
+}

--- a/src/grafter/rdf/sparql.clj
+++ b/src/grafter/rdf/sparql.clj
@@ -142,6 +142,27 @@
 
      (repo/evaluate prepped-query))))
 
+(defn paged-query
+  "Returns a lazy-sequence of pages of e.g. 1000 results
+   (or whatever fraction remains on the last page).
+
+   Use the vars ?batchLimit and ?batchOffset in your query
+   to specify how it should be paged.
+
+   You can use (mapcat identity pages) to get a continuous
+   sequence of results while still having the query submitted
+   in batches."
+  ([query-file bindings repository]
+   (paged-query query-file bindings repository 1000 0))
+  ([query-file bindings repository limit offset]
+   (lazy-seq
+    (let [paged-bindings (merge bindings {::limits {:batchLimit limit}
+                                          ::offsets {:batchOffset offset} })
+          results (query query-file paged-bindings repository)]
+      (if (not (nil? results))
+        (cons results (paged-query query-file bindings repository limit (+ offset limit))))))))
+
+
 (comment
   (def r (repo/resource-repo "grafter/rdf/sparql/sparql-data.trig"))
 

--- a/test/grafter/rdf/sparql_test.clj
+++ b/test/grafter/rdf/sparql_test.clj
@@ -92,3 +92,13 @@
       (is (= 2 (count (spog {:s (URI. "http://example.org/data/another-triple")
                              ::sparql/offsets {0 1}}
                             r)))))))
+
+(deftest paged-query-test
+  (let [r (repo/fixture-repo (resource "grafter/rdf/sparql/sparql-data.trig"))
+        results (paged-query "grafter/rdf/sparql/select-spog-paginated.sparql" {} r 1 0)]
+    (testing "returns pages of results (one per subject)"
+      (is (= 5 (count results))))
+    (testing "page lengths can differ (pageing is in subquery)"
+      (is (= [1 3 1 1 1] (map count results))))
+    (testing "is exhaustive (gets all of the results)"
+      (is (= 7 (count (mapcat identity results)))))))


### PR DESCRIPTION
Here's a proposal for automatically paginating queries. I've kept the results in pages as my (data validation) use case requires that I process whole pages at once (i.e. it's not so much the batching as the discrete pages I'm after).

I used `cons` to join the pages. It looks like this ensures that the results come back in the right order. I believe it also means that the sequence can be garbage collected efficiently (?).