### PR TITLE
Add a version of graph which works on a seq

### DIFF
--- a/src/grafter/rdf/templater.clj
+++ b/src/grafter/rdf/templater.clj
@@ -92,9 +92,12 @@
   and are cast as such, as URI's are the most common type in linked
   data.  If you want an RDF string you should use the s function to
   build one."
-  [graph-uri & triples]
-  (map (partial quad graph-uri)
-       (apply triplify triples)))
+  ([graph-uri triples]
+   (map (partial quad graph-uri)
+        (apply triplify triples)))
+  ([graph-uri & triples]
+   (map (partial quad graph-uri)
+        (apply triplify triples))))
 
 (defn add-properties
   "Appends the key/value pairs from the supplied hash-map into the

--- a/test/grafter/rdf/templater_test.clj
+++ b/test/grafter/rdf/templater_test.clj
@@ -155,4 +155,20 @@
           (is (= "http://example.com/p1" p))
           (is (keyword? o))
           (is (= "http://example.com/graphs/1" c))
-          (is (some (fn [[k v]] (= k o)) quads)))))))
+          (is (some (fn [[k v]] (= k o)) quads)))))
+    (testing "with a seq input"
+      (let [quads (graph "http://example.com/graphs/1" (seq [first-turtle-template second-turtle-template]))]
+        (is (= 6
+               (count quads)))
+        (is (= (->Quad "http://example.com/subjects/1" "http://example.com/p1" "http://example.com/o1" "http://example.com/graphs/1")
+               (first quads)))
+        (let [[s p o c] (first quads)]
+          (is (= "http://example.com/subjects/1" s))
+          (is (= "http://example.com/p1" p))
+          (is (= "http://example.com/o1" o))
+          (is (= "http://example.com/graphs/1" c))
+          (testing "accessor methods"
+            (is (= "http://example.com/subjects/1" (subject (first quads))))
+            (is (= "http://example.com/p1" (predicate (first quads))))
+            (is (= "http://example.com/o1" (object (first quads))))
+            (is (= "http://example.com/graphs/1" (context (first quads))))))))))


### PR DESCRIPTION
I often use the graph version over a lazy seq of templates / triples.
I added a version of `graph` which makes the code a bit nicer to look at.