### PR TITLE
Support parsing [+-]?INF floating literals.

### DIFF
--- a/src/grafter/rdf/io.clj
+++ b/src/grafter/rdf/io.clj
@@ -78,10 +78,20 @@
   (bigdec (pr/raw-value literal)))
 
 (defmethod literal-datatype->type "http://www.w3.org/2001/XMLSchema#double" [literal]
-  (Double/parseDouble (pr/raw-value literal)))
+  (let [raw (pr/raw-value literal)]
+    (case raw
+      "INF" Double/POSITIVE_INFINITY
+      "+INF" Double/POSITIVE_INFINITY
+      "-INF" Double/NEGATIVE_INFINITY
+      (Double/parseDouble raw))))
 
 (defmethod literal-datatype->type "http://www.w3.org/2001/XMLSchema#float" [literal]
-  (Float/parseFloat (pr/raw-value literal)))
+  (let [raw (pr/raw-value literal)]
+    (case raw
+      "INF" Float/POSITIVE_INFINITY
+      "+INF" Float/POSITIVE_INFINITY
+      "-INF" Float/NEGATIVE_INFINITY
+      (Float/parseFloat raw))))
 
 (defmethod literal-datatype->type "http://www.w3.org/2001/XMLSchema#integer" [literal]
   (bigint (pr/raw-value literal)))

--- a/test/grafter/rdf/io_test.clj
+++ b/test/grafter/rdf/io_test.clj
@@ -62,6 +62,17 @@
     (int 42)       "http://www.w3.org/2001/XMLSchema#int" Integer
     "hello"        "http://www.w3.org/2001/XMLSchema#string" String))
 
+(deftest literal-datatype->type-special-floating-values-test
+  (is (Double/isNaN (literal-datatype->type (literal "NaN" "http://www.w3.org/2001/XMLSchema#double"))))
+  (is (= Double/POSITIVE_INFINITY (literal-datatype->type (literal "INF" "http://www.w3.org/2001/XMLSchema#double"))))
+  (is (= Double/POSITIVE_INFINITY (literal-datatype->type (literal "+INF" "http://www.w3.org/2001/XMLSchema#double"))))
+  (is (= Double/NEGATIVE_INFINITY (literal-datatype->type (literal "-INF" "http://www.w3.org/2001/XMLSchema#double"))))
+
+  (is (Float/isNaN (literal-datatype->type (literal "NaN" "http://www.w3.org/2001/XMLSchema#float"))))
+  (is (= Float/POSITIVE_INFINITY (literal-datatype->type (literal "INF" "http://www.w3.org/2001/XMLSchema#float"))))
+  (is (= Float/POSITIVE_INFINITY (literal-datatype->type (literal "+INF" "http://www.w3.org/2001/XMLSchema#float"))))
+  (is (= Float/NEGATIVE_INFINITY (literal-datatype->type (literal "-INF" "http://www.w3.org/2001/XMLSchema#float")))))
+
 (deftest literal-test
   (is (instance? LiteralImpl (->sesame-rdf-type (literal "2014-01-01" (java.net.URI. "http://www.w3.org/2001/XMLSchema#date"))))))
 


### PR DESCRIPTION
XML schema allows the literals INF, +INF and -INF to represent
positive and negative infinity respectively for float and double
types. Support these literals in the implementations of
rdf.io/literal-datatype->type for float and double.