### PR TITLE
Implemented missing method for BooleanLiteralImpl

### DIFF
--- a/src/grafter/rdf/io.clj
+++ b/src/grafter/rdf/io.clj
@@ -232,6 +232,9 @@
   (->sesame-rdf-type [this]
     this)
 
+  (sesame-rdf-type->type [this]
+    (.booleanValue this))
+
   Statement
   (->sesame-rdf-type [this]
     this)


### PR DESCRIPTION
Fixes #136 - implemented missing method sesame-rdf-type->type on protocol ISesameRDFConverter for type BooleanLiteralImpl