### PR TITLE
Remove pantomime dep + bump Clojure dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :deploy-repositories [["releases" :clojars]]
 
-  :dependencies [[org.clojure/clojure "1.9.0-RC1"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.openrdf.sesame/sesame-runtime "2.8.9"]
                  [org.clojure/tools.logging "0.3.1"]
                  [grafter/url "0.2.5"]

--- a/project.clj
+++ b/project.clj
@@ -14,8 +14,7 @@
 
                  [commons-logging "1.2"] ;; Shouldn't need this, but somehow excluded and required by SPARQLRepository
                  [me.raynes/fs "1.4.6"]
-                 [potemkin "0.4.3"]
-                 [com.novemberain/pantomime "2.8.0"]] ;; mimetypes
+                 [potemkin "0.4.3"]]
 
 
   :codox {:defaults {:doc "FIXME: write docs"


### PR DESCRIPTION
Pantomime is no longer used by Grafter to parse MIME types.

Furthermore, Pantomime pulls in a dizzying list of dependencies (e.g. Apache SIS, Open GIS) which can cause all manner of dependency clashes and class-loading issues in client code.

Removed!

#### Update
I just checked the CI build log. The number of individual dep files pulled from Clojars went down from 454 to 232 😃 