### PR TITLE
Explicit :reasoning? opts for sparql/repo queries

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,6 +44,9 @@
                  [me.raynes/fs "1.4.6"]
                  [potemkin "0.4.5"]]
 
+  ;; Ensure we build the java sub project source code too!
+  :java-source-paths ["src-java/grafter_sparql_repository/src/main/java"]
+
   :source-paths ["src" "deprecated/src"]
   :test-paths ["test" "deprecated/test"]
 
@@ -64,6 +67,9 @@
   ;; Swing classes are loaded.
   :jvm-opts ["-Dapple.awt.UIElement=true"]
 
+  ;; Target JDK 8 expected JVM version
+  :javac-options ["-target" "8" "-source" "8"]
+
   :pedantic? true
 
   :profiles { ;; expect upstream projects to provide this explicity if they want sesame
@@ -76,6 +82,7 @@
              :dev-deps {
 
                         :dependencies [
+                                       [http-kit "2.3.0"]
                                        [org.slf4j/slf4j-simple "1.7.25"]
                                        [prismatic/schema "1.1.7"]
                                        [criterium "0.4.4"]]

--- a/src-java/grafter_sparql_repository/.gitignore
+++ b/src-java/grafter_sparql_repository/.gitignore
@@ -1,0 +1,2 @@
+!pom.xml
+target/

--- a/src-java/grafter_sparql_repository/README.md
+++ b/src-java/grafter_sparql_repository/README.md
@@ -1,7 +1,7 @@
 # Grafter SPARQL Repository
 
 This small piece of Java code enhances the SPARQL Repository to behave how we
-want it to when talking to Stardog.
+want it to when talking to SPARQL endpoints, such as Stardog.
 
 It's main job is to centralise how we handle timeouts, query parameters, etc...
 

--- a/src-java/grafter_sparql_repository/README.md
+++ b/src-java/grafter_sparql_repository/README.md
@@ -1,0 +1,19 @@
+# Grafter SPARQL Repository
+
+This small piece of Java code enhances the SPARQL Repository to behave how we
+want it to when talking to Stardog.
+
+It's main job is to centralise how we handle timeouts, query parameters, etc...
+
+## Building
+
+**DON'T BUILD ME!!!**
+
+We never build the java project as a separate artifact, and instead
+just use the `pom.xml` to provide IDE code completion.
+
+This sub project should be built by running `lein uberjar` from the
+top level grafter project directory.
+
+/NOTE/ This project `pom.xml` should be kept in sync with the
+corresponding sesame dependency mentioned in the top level `project.clj`.

--- a/src-java/grafter_sparql_repository/pom.xml
+++ b/src-java/grafter_sparql_repository/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    NOTE: This pom.xml is intended to be used in development to provide code completion
+          to intelliJ or your IDE only.  We don't actually build a maven artifact for this
+          dependency and instead just set the :java-source-paths in the parent leiningen project
+          to build and include ./src/main/java for us.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>swirrl</groupId>
+    <artifactId>grafter-sparql-repository</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>clojars.org</id>
+            <name>Clojars repository</name>
+            <url>http://clojars.org/repo</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>s3-wagon-private</groupId>
+                <artifactId>s3-wagon-private</artifactId>
+                <version>1.3.0</version>
+            </extension>
+        </extensions>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <!--
+                NOTE: this version of sesame should be kept in sync with the version in the parent
+                leiningen project.clj.
+            -->
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-runtime</artifactId>
+            <version>2.2.2</version>
+            <!--<exclusions>-->
+                <!--<exclusion>-->
+                    <!--<groupId>org.openrdf.sesame</groupId>-->
+                    <!--<artifactId>sesame-http-client</artifactId>-->
+                <!--</exclusion>-->
+            <!--</exclusions>-->
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>swirrl-jars-releases</id>
+            <name>SWIRRL release jars</name>
+            <url>s3p://swirrl-jars/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>swirrl-jars-snapshots</id>
+            <name>SWIRRL SNAPSHOT jars</name>
+            <url>s3p://swirrl-jars/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+</project>

--- a/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLClientImpl.java
+++ b/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLClientImpl.java
@@ -1,0 +1,23 @@
+package grafter_2.rdf;
+
+import org.apache.http.client.HttpClient;
+import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
+import org.eclipse.rdf4j.http.client.SharedHttpClientSessionManager;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class SPARQLClientImpl extends SharedHttpClientSessionManager {
+
+    private static final ExecutorService QUERY_EXECUTOR = Executors.newCachedThreadPool();
+
+    public SPARQLClientImpl(HttpClient httpClient) {
+        this.setHttpClient(httpClient);
+    }
+
+    @Override public SPARQLProtocolSession createSPARQLProtocolSession(String queryEndpointUrl, String updateEndpointUrl) {
+        SPARQLSession session = new SPARQLSession(queryEndpointUrl, updateEndpointUrl, this.getHttpClient(), QUERY_EXECUTOR);
+
+        return session;
+    }
+}

--- a/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLConnection.java
+++ b/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLConnection.java
@@ -1,0 +1,40 @@
+package grafter_2.rdf;
+
+import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
+import org.eclipse.rdf4j.query.*;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
+import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
+
+
+public class SPARQLConnection extends org.eclipse.rdf4j.repository.sparql.SPARQLConnection {
+
+    public SPARQLConnection(SPARQLRepository repository, SPARQLProtocolSession sparqlSession, boolean quadMode) {
+        super(repository, sparqlSession, quadMode);
+    }
+
+    public SPARQLConnection(SPARQLRepository repository, SPARQLProtocolSession sparqlSession) {
+        super(repository, sparqlSession, false);
+    }
+
+    @Override public BooleanQuery prepareBooleanQuery(QueryLanguage ql, String query, String base) throws RepositoryException, MalformedQueryException {
+        return handleOp(super.prepareBooleanQuery(ql, query, base));
+    }
+
+    @Override public GraphQuery prepareGraphQuery(QueryLanguage ql, String query, String base) throws RepositoryException, MalformedQueryException {
+        return handleOp(super.prepareGraphQuery(ql, query, base));
+    }
+
+    @Override public TupleQuery prepareTupleQuery(QueryLanguage ql, String query, String base) throws RepositoryException, MalformedQueryException {
+        return handleOp(super.prepareTupleQuery(ql, query, base));
+    }
+
+    @Override public Update prepareUpdate(QueryLanguage ql, String update, String baseURI) throws RepositoryException, MalformedQueryException {
+        return handleOp(super.prepareUpdate(ql, update, baseURI));
+    }
+
+    private static <O extends Operation> O handleOp(O op) {
+        op.setIncludeInferred(false);
+        return op;
+    }
+}

--- a/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLRepository.java
+++ b/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLRepository.java
@@ -1,0 +1,100 @@
+package grafter_2.rdf;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.eclipse.rdf4j.http.client.HttpClientSessionManager;
+import org.eclipse.rdf4j.http.client.SesameClient;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+
+public class SPARQLRepository extends org.eclipse.rdf4j.repository.sparql.SPARQLRepository {
+
+    private HttpClientSessionManager httpClientManager;
+    private Integer maxConcurrentHttpConnections;
+    private boolean quadMode = false;
+
+    public SPARQLRepository(String queryEndpoint) { super(queryEndpoint); }
+    public SPARQLRepository(String queryEndpoint, String updateEndpoint) {
+        super(queryEndpoint, updateEndpoint);
+    }
+
+     @Override public RepositoryConnection getConnection() throws RepositoryException {
+         if(!this.isInitialized()) {
+             throw new RepositoryException("SPARQLRepository not initialized.");
+         } else {
+             return new SPARQLConnection(this, createHTTPClient(), quadMode);
+         }
+     }
+
+     public synchronized HttpClientSessionManager getHttpClientSessionManager() {
+         if (this.httpClientManager == null) {
+             HttpClient httpClient = newHttpClient();
+             this.httpClientManager = new SPARQLClientImpl(httpClient);
+         }
+         return this.httpClientManager;
+     }
+
+    /**
+     * Activate quad mode for this {@link SPARQLRepository}, i.e. for retrieval of statements also retrieve
+     * the graph.
+     * <p>
+     * Note: the setting is only applied in newly created {@link SPARQLConnection}s as the setting is an
+     * immutable configuration of a connection instance.
+     *
+     * @param flag
+     *        flag to enable or disable the quad mode
+     * @see SPARQLConnection#getStatements(org.eclipse.rdf4j.model.Resource, org.eclipse.rdf4j.model.URI,
+     *      org.eclipse.rdf4j.model.Value, boolean, org.eclipse.rdf4j.model.Resource...)
+     */
+    public void enableQuadMode(boolean flag) {
+        this.quadMode = flag;
+    }
+
+    @Override public synchronized void setHttpClientSessionManager(HttpClientSessionManager httpMan) {
+        this.httpClientManager = httpMan;
+    }
+
+    /**
+     * Gets the maximum number of concurrent TCP connections created per route
+     * in the HTTP client used by this repository.
+     * @return The maximum number of concurrent connections
+     */
+    public synchronized Integer getMaxConcurrentHttpConnections() {
+        return this.maxConcurrentHttpConnections;
+    }
+
+    /**
+     * Sets the number of concurrent TCP connections allowed per route for the
+     * HTTP client used by this repository
+     * @param maxConcurrentHttpConnections The maximum number of connections
+     */
+    public synchronized void setMaxConcurrentHttpConnections(Integer maxConcurrentHttpConnections) {
+        this.maxConcurrentHttpConnections = maxConcurrentHttpConnections;
+
+        //number of max concurrent connections might have changed so reset client so it will be re-created
+        //on next usage with new maximum
+        this.setSesameClient(null);
+    }
+
+    // Fix for: https://github.com/eclipse/rdf4j/issues/367
+    private synchronized HttpClient newHttpClient() {
+        // the 'system' HTTP client uses the http.maxConnections system property
+        // to define the size of its connection pool (5 is the default if
+        // unset). Temporarily set this property to maxConcurrentHttpConnections
+        // if specified for this repository.
+        // TODO: Construct a builder which specifies all relevant settings
+        // directly
+        final String maxConnKey = "http.maxConnections";
+        final String existingMax = System.getProperty(maxConnKey, "5");
+        try {
+            Integer maxConns = this.getMaxConcurrentHttpConnections();
+            if (maxConns != null) {
+                System.setProperty(maxConnKey, maxConns.toString());
+            }
+            return HttpClients.createSystem();
+        }
+        finally {
+            System.setProperty(maxConnKey, existingMax);
+        }
+    }
+}

--- a/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLSession.java
+++ b/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLSession.java
@@ -1,0 +1,213 @@
+package grafter_2.rdf;
+
+import org.apache.http.*;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.client.params.CookiePolicy;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.ConnectionPoolTimeoutException;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.CoreConnectionPNames;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.rdf4j.OpenRDFException;
+import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
+import org.eclipse.rdf4j.http.client.SparqlSession;
+import org.eclipse.rdf4j.http.protocol.UnauthorizedException;
+import org.eclipse.rdf4j.http.protocol.error.ErrorInfo;
+import org.eclipse.rdf4j.http.protocol.error.ErrorType;
+import org.eclipse.rdf4j.query.*;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+public class SPARQLSession extends SPARQLProtocolSession /*SparqlSession*/ {
+
+    public SPARQLSession(String queryEndpointUrl, String updateEndpointUrl, HttpClient client, ExecutorService executor) {
+        super(client, executor);
+        this.setQueryURL(queryEndpointUrl);
+        this.setUpdateURL(updateEndpointUrl);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T readField(Class cls, Object receiver, String fieldName) {
+        try {
+            Field f = cls.getDeclaredField(fieldName);
+            f.setAccessible(true);
+            return (T)f.get(receiver);
+        } catch(NoSuchFieldException ex) {
+            throw new RuntimeException(String.format("Field %s in class %s does not exist", fieldName, cls.getName()));
+        } catch (IllegalAccessException ex) {
+            throw new RuntimeException(String.format("Field %s in class %s is not accessible", fieldName, cls.getName()));
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    /**
+     * Constructs the parameters to be used by the HTTP request. This is based on the params member of SparqlSession
+     * which is configured within the constructor and by setConnectionTimeout in the base class.
+     */
+    private HttpParams getHttpParams() {
+        BasicHttpParams params = new BasicHttpParams();
+        params.setBooleanParameter(ClientPNames.HANDLE_REDIRECTS, true);
+        params.setParameter(ClientPNames.COOKIE_POLICY, CookiePolicy.RFC_2109);
+
+        //set timeouts:
+        // - SO_TIMEOUT is the timeout between consecutive data packets received by the underlying connection
+        // - CONNECTION_TIMEOUT is the time to establish the TCP connection
+        // - CONN_MANAGER_TIMEOUT is the timeout for obtaining a connection from the connection pool
+        int socketTimeout = (int)this.getConnectionTimeout();
+        params.setIntParameter(CoreConnectionPNames.SO_TIMEOUT, socketTimeout);
+        HttpConnectionParams.setConnectionTimeout(params, 100);
+        params.setLongParameter(ClientPNames.CONN_MANAGER_TIMEOUT,1);
+
+        return params;
+    }
+
+    private HttpClientContext getHttpContext() {
+        return readField(SPARQLProtocolSession.class, this, "httpContext");
+    }
+
+    /**
+     * Inspects a HTTP response returned from the server and checks if it looks like a timeout.
+     * @param response The HTTP response returned from the server
+     * @return Whether the received response looks like a query timeout response
+     */
+    private boolean isStardogTimeoutResponse(HttpResponse response) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        Header errorCodeHeader = response.getFirstHeader("SD-Error-Code");
+        if (    statusCode == HttpURLConnection.HTTP_INTERNAL_ERROR &&
+                errorCodeHeader != null &&
+                "QueryEval".equals(errorCodeHeader.getValue())) {
+            HttpEntity entity = response.getEntity();
+            try {
+                //inspect the message in the response to see if it indicates a query timeout
+                String body = EntityUtils.toString(entity);
+                return body != null && body.contains("exceeded query timeout");
+            }
+            catch (IOException ex) {
+                return false;
+            }
+            catch (ParseException ex) {
+                return false;
+            }
+        }
+        else return false;
+    }
+
+    private static final String INCLUDE_INFERRED_PARAM_NAME = "infer";
+    private static final String STARDOG_INFERRED_PARAM_NAME = "reasoning";
+    private static final String TIMEOUT_QUERY_PARAM_NAME = "timeout";
+
+    private static void removeTimeoutQueryParams(List<NameValuePair> queryPairs) {
+        List<NameValuePair> toRemove = new ArrayList<NameValuePair>();
+        for(NameValuePair pair : queryPairs) {
+            if(TIMEOUT_QUERY_PARAM_NAME.equals(pair.getName())) {
+                toRemove.add(pair);
+            }
+        }
+        queryPairs.removeAll(toRemove);
+    }
+
+    @Override protected List<NameValuePair> getQueryMethodParameters(QueryLanguage ql, String query, String baseURI, Dataset dataset, boolean includeInferred, int maxQueryTime, Binding... bindings) {
+        List<NameValuePair> pairs = super.getQueryMethodParameters(ql, query, baseURI, dataset, includeInferred, maxQueryTime, bindings);
+
+        // SPARQLProtocolSession (super) only implements standard query
+        // parameters so if we want to send reasoning parameters we have to add
+        // them ourselves. We're adding both stardog's param, and rdf4j's param
+        // because stardog just ignores `infer` and so this should work on any
+        // server that uses `infer` and ignores `reasoning` as well.
+        if (includeInferred) {
+            pairs.add(new BasicNameValuePair(INCLUDE_INFERRED_PARAM_NAME, "true"));
+            pairs.add(new BasicNameValuePair(STARDOG_INFERRED_PARAM_NAME, "true"));
+        }
+
+        //sesame adds a timeout=period_seconds query parameter if the maximum query time is set
+        //remove this parameter and replace it with our own
+        removeTimeoutQueryParams(pairs);
+
+        //add timeout if specified (i.e. maxQueryTime > 0)
+        if(maxQueryTime > 0) {
+            //add Stardog timeout=period_ms query parameter
+            //maxQueryTime is the maximum time in seconds whereas Stardog's timeout is measured in Milliseconds
+            Integer timeoutMs = 1000 * maxQueryTime;
+            pairs.add(new BasicNameValuePair(TIMEOUT_QUERY_PARAM_NAME, timeoutMs.toString()));
+        }
+
+        return pairs;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override protected HttpResponse execute(HttpUriRequest method) throws IOException, OpenRDFException {
+        //NOTE: the implementation of this method is based on SparqlSession.execute(HttpUriRequest)
+        //This class cannot access the private HttpClientContext fields used by the base implementation
+        //so fetches it using reflection(!). It also inspects the received response to check if it appears to indicate
+        //a query timeout and throws a QueryInterruptedException in that case.
+        HttpClient httpClient = getHttpClient();
+        HttpClientContext httpContext = getHttpContext();
+
+        boolean consume = true;
+
+        HttpParams params = getHttpParams();
+        method.setParams(params);
+        HttpResponse response;
+        try {
+            response = httpClient.execute(method, httpContext);
+        }
+        catch (ConnectionPoolTimeoutException ex) {
+            throw new QueryInterruptedException("Error executing query against remote endpoint.", ex);
+        }
+
+        try {
+            int httpCode = response.getStatusLine().getStatusCode();
+            if (httpCode >= 200 && httpCode < 300 || httpCode == HttpURLConnection.HTTP_NOT_FOUND) {
+                consume = false;
+                return response; // everything OK, control flow can continue
+            }
+            else if (isStardogTimeoutResponse(response)) {
+                throw new QueryInterruptedException();
+            }
+            else {
+                switch (httpCode) {
+                    case HttpURLConnection.HTTP_UNAUTHORIZED: // 401
+                        throw new UnauthorizedException();
+                    case HttpURLConnection.HTTP_UNAVAILABLE: // 503
+                        throw new QueryInterruptedException();
+                    default:
+                        ErrorInfo errInfo = getErrorInfo(response);
+                        // Throw appropriate exception
+                        if (errInfo.getErrorType() == ErrorType.MALFORMED_DATA) {
+                            throw new RDFParseException(errInfo.getErrorMessage());
+                        }
+                        else if (errInfo.getErrorType() == ErrorType.UNSUPPORTED_FILE_FORMAT) {
+                            throw new UnsupportedRDFormatException(errInfo.getErrorMessage());
+                        }
+                        else if (errInfo.getErrorType() == ErrorType.MALFORMED_QUERY) {
+                            throw new MalformedQueryException(errInfo.getErrorMessage());
+                        }
+                        else if (errInfo.getErrorType() == ErrorType.UNSUPPORTED_QUERY_LANGUAGE) {
+                            throw new UnsupportedQueryLanguageException(errInfo.getErrorMessage());
+                        }
+                        else {
+                            throw new RepositoryException(errInfo.toString());
+                        }
+                }
+            }
+        }
+        finally {
+            if (consume) {
+                EntityUtils.consumeQuietly(response.getEntity());
+            }
+        }
+    }
+}

--- a/src/grafter_2/rdf/protocols.clj
+++ b/src/grafter_2/rdf/protocols.clj
@@ -87,7 +87,9 @@
         (println res)))
   ````"
   ;; TODO: reimplement interfaces with proper resource handling.
-  (query-dataset [this sparql-string model]))
+  (query-dataset
+    [this sparql-string model]
+    [this sparql-string model opts]))
 
 (defprotocol IGrafterRDFType
   "This protocol coerces a backend RDF type, e.g. an RDF4j quad object

--- a/src/grafter_2/rdf4j/repository.clj
+++ b/src/grafter_2/rdf4j/repository.clj
@@ -10,14 +10,14 @@
            [org.eclipse.rdf4j.query BindingSet BooleanQuery GraphQuery Query QueryLanguage TupleQuery Update]
            [org.eclipse.rdf4j.repository Repository RepositoryConnection]
            [org.eclipse.rdf4j.sail.inferencer.fc CustomGraphQueryInferencer DirectTypeHierarchyInferencer ForwardChainingRDFSInferencer])
-  (:import grafter_2.rdf.protocols.IStatement
+  (:import grafter_2.rdf.SPARQLRepository
+           grafter_2.rdf.protocols.IStatement
            org.eclipse.rdf4j.common.iteration.CloseableIteration
            org.eclipse.rdf4j.model.impl.URIImpl
            org.eclipse.rdf4j.query.impl.DatasetImpl
            org.eclipse.rdf4j.repository.event.base.NotifyingRepositoryWrapper
            org.eclipse.rdf4j.repository.http.HTTPRepository
            org.eclipse.rdf4j.repository.sail.SailRepository
-           org.eclipse.rdf4j.repository.sparql.SPARQLRepository
            org.eclipse.rdf4j.sail.memory.MemoryStore
            org.eclipse.rdf4j.sail.nativerdf.NativeStore))
 

--- a/src/grafter_2/rdf4j/repository.clj
+++ b/src/grafter_2/rdf4j/repository.clj
@@ -327,8 +327,9 @@
        (reduce f val c))))
 
   pr/ISPARQLable
-  (pr/query-dataset [this query-str model]
-    (throw-deprecated-exception!))
+  (pr/query-dataset
+    ([this query-str model] (throw-deprecated-exception!))
+    ([this query-str model opts] (throw-deprecated-exception!)))
 
   pr/ISPARQLUpdateable
   (pr/update! [this query-str]
@@ -443,7 +444,10 @@
   Prepared queries still need to be evaluated with evaluate."
   ([repo sparql-string] (prepare-query repo sparql-string nil))
   ([repo sparql-string restriction]
-   (prepare-query* repo sparql-string restriction)))
+   (prepare-query repo sparql-string restriction nil))
+  ([repo sparql-string restriction {:keys [reasoning?] :as opts}]
+   (doto (prepare-query* repo sparql-string restriction)
+     (.setIncludeInferred (or reasoning? false)))))
 
 (defn prepare-update
   "Prepare (parse but don't process) a SPARQL update request.
@@ -469,9 +473,12 @@
      (reduce f val (pr/to-statements this {}))))
 
   pr/ISPARQLable
-  (pr/query-dataset [this sparql-string dataset]
-    (let [preped-query (prepare-query this sparql-string dataset)]
-      (evaluate preped-query)))
+  (pr/query-dataset
+    ([this sparql-string dataset]
+     (pr/query-dataset this sparql-string dataset {}))
+    ([this sparql-string dataset opts]
+     (let [preped-query (prepare-query this sparql-string dataset opts)]
+       (evaluate preped-query))))
 
   pr/ISPARQLUpdateable
   (pr/update! [this sparql-string]
@@ -586,11 +593,14 @@
 
   Options are:
 
-  - `:default-graph` a seq of URI strings representing named graphs to be set
-    as the default union graph for the query.
+  - `:default-graph` a seq of URI strings representing named graphs to be set as
+    the default union graph for the query.
 
-  - `:named-graphs` a seq of URI strings representing the named graphs in
-    to be used in the query.
+  - `:named-graphs` a seq of URI strings representing the named graphs to be
+    used in the query.
+
+  - `:reasoning?` `true|false` whether or not reasoning/inference should be used
+  in the query. DEFAULT: `false`
 
   If no options are passed then we use the default of no graph
   restrictions whilst the union graph is the union of all graphs."
@@ -600,7 +610,7 @@
   ;; prefixes onto the SPARQL string ourselves.
   (let [sparql (str (build-sparql-prefixes-block prefixes) sparql)
         dataset (mapply make-restricted-dataset (or options {}))]
-    (pr/query-dataset repo sparql dataset)))
+    (pr/query-dataset repo sparql dataset options)))
 
 (extend-type RepositoryConnection
   pr/ITripleReadable

--- a/test/grafter_2/rdf/sparql_repository_test.clj
+++ b/test/grafter_2/rdf/sparql_repository_test.clj
@@ -1,0 +1,45 @@
+(ns grafter-2.rdf.sparql-repository-test
+  "Simple test to ensure that `grafter_2.rdf.SPARQLSession` is forwarding the
+  rdf4j infer/reasoning query parameters to a remote server."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [grafter-2.rdf4j.repository :as repo]
+            [org.httpkit.server :refer [run-server]]
+            [clojure.string :as string])
+  (:import java.net.URLDecoder))
+
+(def host "localhost")
+(def port 5821)
+(def db "http-test-db")
+(def query-endpoint (format "http://%s:%s/%s/query" host port db))
+
+(def simple-query "ASK { :rick a foaf:Person . }")
+
+(defn parse-query-string [s]
+  (->> (string/split s #"&")
+       (map (fn [pair]
+              (let [[k v] (string/split pair #"=")]
+                [(keyword (URLDecoder/decode k)) (URLDecoder/decode v)])))
+       (into {})))
+
+(def handler
+  (letfn [(respond [reasoning?]
+            {:status 200
+             :headers {"Content-Type" "text/boolean"}
+             :body (pr-str reasoning?)})]
+    (fn [{:keys [query-string] :as request}]
+      (let [{:keys [infer reasoning query]} (parse-query-string query-string)]
+        (assert (= query simple-query))
+        (respond
+         (and (Boolean/parseBoolean infer) (Boolean/parseBoolean reasoning)))))))
+
+(defn http-kit-server-fixture [f]
+  (let [stop (run-server #'handler {:port port})]
+    (f)
+    (stop)))
+
+(use-fixtures :each http-kit-server-fixture)
+
+(deftest simple-http-query-inference-test
+  (let [repo (repo/sparql-repo query-endpoint)]
+    (is (true? (repo/query (repo/->connection repo) simple-query :reasoning? true)))
+    (is (false? (repo/query (repo/->connection repo) simple-query :reasoning? false)))))

--- a/test/grafter_2/rdf4j/repository_test.clj
+++ b/test/grafter_2/rdf4j/repository_test.clj
@@ -167,10 +167,18 @@
                     "geopos" "http://www.w3.org/2003/01/geo/wgs84_pos#"}]
       (with-open [c (->connection r)]
         (testing "RDFS Inference"
-          (is (query c "ASK { :rick a foaf:Person . }" :prefixes prefixes))
-          (is (query c "ASK { :manchester a geopos:SpatialThing . }" :prefixes prefixes))
-          (is (query c "ASK { :swirrl a foaf:Agent . }" :prefixes prefixes))
-          (is (query c "ASK { <http://swirrl.com/> a foaf:Document . }" :prefixes prefixes)))))))
+          (is (query c "ASK { :rick a foaf:Person . }"
+                     :prefixes prefixes
+                     :reasoning? true))
+          (is (query c "ASK { :manchester a geopos:SpatialThing . }"
+                     :prefixes prefixes
+                     :reasoning? true))
+          (is (query c "ASK { :swirrl a foaf:Agent . }"
+                     :prefixes prefixes
+                     :reasoning? true))
+          (is (query c "ASK { <http://swirrl.com/> a foaf:Document . }"
+                     :prefixes prefixes
+                     :reasoning? true)))))))
 
 
 (comment


### PR DESCRIPTION
Enable reasoning/inference to be turned on explicitly in an `opts` map for `grafter-2.rdf4j.repository/query` and `grafter-2.rdf4j.sparql/query`, defaulting to `off|false`.

Necessary to implement https://github.com/Swirrl/grafter.db/issues/1