### PR TITLE
Depend on Sesame classes within legacy grafter.* namespaces.

### DIFF
--- a/deprecated/src/grafter/rdf/repository/registry.clj
+++ b/deprecated/src/grafter/rdf/repository/registry.clj
@@ -18,11 +18,10 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log])
   (:import [java.nio.charset Charset]
-           [org.eclipse.rdf4j.rio RDFParserRegistry RDFFormat]
-           [org.eclipse.rdf4j.query.resultio TupleQueryResultFormat BooleanQueryResultFormat
+           [org.openrdf.rio RDFParserRegistry RDFFormat]
+           [org.openrdf.query.resultio TupleQueryResultFormat BooleanQueryResultFormat
             TupleQueryResultParserRegistry
-            BooleanQueryResultParserRegistry]
-           [org.eclipse.rdf4j.query.resultio.text.csv SPARQLResultsCSVParserFactory]))
+            BooleanQueryResultParserRegistry]))
 
 
 (defn parser-registries
@@ -88,23 +87,23 @@
 
   (registered-parser-factories) ;; =>
 
-  {:select #{org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLParserFactory
-             org.eclipse.rdf4j.query.resultio.text.csv.SPARQLResultsCSVParserFactory
-             org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONParserFactory
-             org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVParserFactory
-             org.eclipse.rdf4j.query.resultio.binary.BinaryQueryResultParserFactory},
-   :construct #{org.eclipse.rdf4j.rio.ntriples.NTriplesParserFactory
-                org.eclipse.rdf4j.rio.trix.TriXParserFactory
-                org.eclipse.rdf4j.rio.jsonld.JSONLDParserFactory
-                org.eclipse.rdf4j.rio.trig.TriGParserFactory
-                org.eclipse.rdf4j.rio.binary.BinaryRDFParserFactory
-                org.eclipse.rdf4j.rio.n3.N3ParserFactory
-                org.eclipse.rdf4j.rio.rdfjson.RDFJSONParserFactory
-                org.eclipse.rdf4j.rio.rdfxml.RDFXMLParserFactory
-                org.eclipse.rdf4j.rio.nquads.NQuadsParserFactory},
-   :ask #{org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLBooleanJSONParserFactory
-          org.eclipse.rdf4j.query.resultio.text.BooleanTextParserFactory
-          org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLBooleanXMLParserFactory}}
+  {:select #{org.openrdf.query.resultio.sparqlxml.SPARQLResultsXMLParserFactory
+             org.openrdf.query.resultio.text.csv.SPARQLResultsCSVParserFactory
+             org.openrdf.query.resultio.sparqljson.SPARQLResultsJSONParserFactory
+             org.openrdf.query.resultio.text.tsv.SPARQLResultsTSVParserFactory
+             org.openrdf.query.resultio.binary.BinaryQueryResultParserFactory},
+   :construct #{org.openrdf.rio.ntriples.NTriplesParserFactory
+                org.openrdf.rio.trix.TriXParserFactory
+                org.openrdf.rio.jsonld.JSONLDParserFactory
+                org.openrdf.rio.trig.TriGParserFactory
+                org.openrdf.rio.binary.BinaryRDFParserFactory
+                org.openrdf.rio.n3.N3ParserFactory
+                org.openrdf.rio.rdfjson.RDFJSONParserFactory
+                org.openrdf.rio.rdfxml.RDFXMLParserFactory
+                org.openrdf.rio.nquads.NQuadsParserFactory},
+   :ask #{org.openrdf.query.resultio.sparqljson.SPARQLBooleanJSONParserFactory
+          org.openrdf.query.resultio.text.BooleanTextParserFactory
+          org.openrdf.query.resultio.sparqlxml.SPARQLBooleanXMLParserFactory}}
 
 
   ;; Once you have the datastructure above, you can adjust it as
@@ -112,7 +111,7 @@
 
   (let [updated-registries (update (registered-parser-factories)
                                    ;; Force removal of TurtleParser
-                                   :construct #(disj % org.eclipse.rdf4j.rio.turtle.TurtleParserFactory))]
+                                   :construct #(disj % org.openrdf.rio.turtle.TurtleParserFactory))]
 
     ;; reset the registered parsers
     (register-parser-factories! updated-registries))

--- a/deprecated/src/grafter/rdf/templater.clj
+++ b/deprecated/src/grafter/rdf/templater.clj
@@ -8,7 +8,7 @@
   (:require [grafter.rdf :as rdf]
             [grafter.url :as url]
             [grafter.rdf.protocols :refer [->Triple ->Quad]])
-  (:import [org.eclipse.rdf4j.model URI]))
+  (:import [org.openrdf.model URI]))
 
 (defn- valid-uri? [node]
   (let [types [java.lang.String java.net.URL java.net.URI URI]]


### PR DESCRIPTION
Issue #148 - Update the imports within the deprecated
grafter.rdf.repository.registry and grafter.rdf.templater namespaces
to use the org.openrdf.* Sesame classes instead of those from RDF4j.

This allows clients wishing to use the legacy namespaces to exclude
all RDF4j dependencies.