### PR TITLE
Upgrade rdf4j to 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: clojure
 sudo: required
 lein: 2.7.1
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_install:
   - sudo ./travis/setup-lein-travis.sh
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject grafter/grafter "2.0.3-SNAPSHOT"
+(defproject grafter/grafter "2.0.4-SNAPSHOT"
   :description "Tools for the hard graft of linked data processing"
   :url "http://grafter.org/"
   :license {:name "Eclipse Public License - v1.0"
@@ -10,36 +10,36 @@
 
   :dependencies [[org.clojure/clojure "1.10.0"]
 
-                 ;;[org.eclipse.rdf4j/rdf4j-runtime "2.5.0" :exclusions [ch.qos.logback/logback-classic]]
+                 ;;[org.eclipse.rdf4j/rdf4j-runtime "3.0.0" :exclusions [ch.qos.logback/logback-classic]]
 
                  ;; Include a smaller set of dependencies than we used
                  ;; to by default, if you want everything from RDF4j
                  ;; you can include:
 
                  ;; [org.eclipse.rdf4j/rdf4j-runtime "2.5.0" :exclusions [ch.qos.logback/logback-classic]]
-                 [org.eclipse.rdf4j/rdf4j-rio-api "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-rio-binary "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-rio-jsonld "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-rio-n3 "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-rio-nquads "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-rio-rdfjson "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-rio-rdfxml "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-rio-trig "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-rio-trix "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-queryresultio-api "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-queryresultio-binary "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-queryresultio-binary "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-queryresultio-sparqljson "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-queryresultio-sparqlxml "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-queryresultio-text "2.5.0"]
+                 [org.eclipse.rdf4j/rdf4j-rio-api "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-rio-binary "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-rio-jsonld "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-rio-n3 "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-rio-nquads "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-rio-rdfjson "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-rio-rdfxml "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-rio-trig "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-rio-trix "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-queryresultio-api "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-queryresultio-binary "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-queryresultio-binary "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-queryresultio-sparqljson "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-queryresultio-sparqlxml "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-queryresultio-text "3.0.0"]
 
-                 [org.eclipse.rdf4j/rdf4j-repository-api "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-repository-http "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-repository-sail "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-repository-dataset "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-sail-memory "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-sail-nativerdf "2.5.0"]
-                 [org.eclipse.rdf4j/rdf4j-repository-manager "2.5.0"]
+                 [org.eclipse.rdf4j/rdf4j-repository-api "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-repository-http "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-repository-sail "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-repository-dataset "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-sail-memory "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-sail-nativerdf "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-repository-manager "3.0.0"]
 
                  [grafter/url "0.2.5"]
                  [grafter/vocabularies "0.2.6"]

--- a/project.clj
+++ b/project.clj
@@ -38,6 +38,7 @@
                  [org.eclipse.rdf4j/rdf4j-repository-sail "3.0.0"]
                  [org.eclipse.rdf4j/rdf4j-repository-dataset "3.0.0"]
                  [org.eclipse.rdf4j/rdf4j-sail-memory "3.0.0"]
+                 [org.eclipse.rdf4j/rdf4j-sail-inferencer "3.0.0"]
                  [org.eclipse.rdf4j/rdf4j-sail-nativerdf "3.0.0"]
                  [org.eclipse.rdf4j/rdf4j-repository-manager "3.0.0"]
 

--- a/src/grafter_2/rdf4j/io.clj
+++ b/src/grafter_2/rdf4j/io.clj
@@ -690,8 +690,6 @@
   org.eclipse.rdf4j.model.URI
   (->-rdf4j-uri [this] this)
   GrafterURL
-  (->-rdf4j-uri [this] (URIImpl. (str this)))
-  org.eclipse.rdf4j.model.Graph
   (->-rdf4j-uri [this] (URIImpl. (str this))))
 
 (defn statements

--- a/src/grafter_2/rdf4j/io.clj
+++ b/src/grafter_2/rdf4j/io.clj
@@ -13,7 +13,7 @@
            [java.net MalformedURLException URL]
            java.time.temporal.ChronoField
            [javax.xml.datatype DatatypeConstants DatatypeFactory XMLGregorianCalendar]
-           [org.eclipse.rdf4j.model BNode Literal Statement URI]
+           [org.eclipse.rdf4j.model BNode Literal Statement URI Model]
            [org.eclipse.rdf4j.model.impl BNodeImpl ContextStatementImpl LiteralImpl SimpleValueFactory StatementImpl URIImpl]
            [org.eclipse.rdf4j.rio RDFFormat RDFHandler Rio]))
 
@@ -663,7 +663,12 @@
 
   java.io.Reader
   (pr/to-statements [this opts]
-    (to-statements* this opts)))
+    (to-statements* this opts))
+
+  Model
+  (to-statements [this _opts]
+    ;; Works because a Model is a java.util.Set
+    (map backend-quad->grafter-quad this)))
 
 (extend-protocol IURIable
   org.eclipse.rdf4j.model.URI

--- a/src/grafter_2/rdf4j/repository.clj
+++ b/src/grafter_2/rdf4j/repository.clj
@@ -6,7 +6,7 @@
             [grafter-2.rdf4j.formats :as format]
             [grafter-2.rdf4j.io :as rio]
             [me.raynes.fs :as fs])
-  (:import [org.eclipse.rdf4j.model Graph Resource Statement URI]
+  (:import [org.eclipse.rdf4j.model Resource Statement URI]
            [org.eclipse.rdf4j.query BindingSet BooleanQuery GraphQuery Query QueryLanguage TupleQuery Update]
            [org.eclipse.rdf4j.repository Repository RepositoryConnection]
            [org.eclipse.rdf4j.sail.inferencer.fc CustomGraphQueryInferencer DirectTypeHierarchyInferencer ForwardChainingRDFSInferencer])
@@ -338,35 +338,6 @@
   pr/ITripleReadable
   (pr/to-statements [this options]
     (throw-deprecated-exception!)))
-
-(extend-type Graph
-  pr/ITripleReadable
-  (pr/to-statements [this options]
-    (map rio/backend-quad->grafter-quad (iterator-seq (.match this nil nil nil (resource-array)))))
-
-  pr/ITripleWriteable
-
-  (pr/add-statement
-    ([this graph statement]
-     (.add this
-           (rio/->backend-type (pr/subject statement))
-           (rio/->backend-type (pr/predicate statement))
-           (rio/->backend-type (pr/object statement))
-           (resource-array (rio/->rdf4j-uri graph)))))
-
-  (pr/add
-    ([this triples]
-     (pr/add this nil triples))
-
-    ([this graph triples]
-     (doseq [triple triples]
-       (pr/add-statement this graph triple)))
-
-    ([this graph format triple-stream]
-     (pr/add this graph triple-stream))
-
-    ([this graph base-uri format triple-stream]
-     (pr/add this graph triple-stream))))
 
 (defn ^:no-doc sesame-results->seq
   "Convert a sesame results object into a lazy sequence of results."

--- a/test/grafter_2/rdf4j/repository_test.clj
+++ b/test/grafter_2/rdf4j/repository_test.clj
@@ -7,23 +7,11 @@
             [grafter-2.rdf4j.templater :refer [graph]]
             [grafter.url :refer [->GrafterURL]])
   (:import [java.net URI URL]
-           org.eclipse.rdf4j.model.impl.GraphImpl
            org.eclipse.rdf4j.repository.sparql.SPARQLRepository))
 
 (def quad-fixture-file-path (io/resource "grafter/rdf/rdf-types.trig"))
 
 (def triple-fixture-file-path (io/resource "grafter/rdf/rdf-types.ttl"))
-
-(deftest reading-writing-to-Graph
-  (let [graph (GraphImpl.)
-        g (URI. "http://foo")
-        s (URI. "http://s")
-        p (URI. "http://p")
-        o (URI. "http://o")]
-    (core/add-statement graph "http://foo" (core/->Quad s p o nil))
-
-    (is (= (core/->Quad s p o g)
-           (first (rio/statements graph))))))
 
 (deftest with-transaction-test
   (with-open [test-db (repo/->connection (sail-repo))]


### PR DESCRIPTION
This upgrades rdf4j to 3.0.0 and makes the required changes for grafter to support it. It also adds support for getting statements out of rdf4j `Model`s.

For the curious, some details about what changed: [release notes](https://rdf4j.eclipse.org/release-notes/#3-0-0), [backward incompatible changes](https://github.com/eclipse/rdf4j/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3A%22Not+backwards+compatible%22+-label%3A%22wontfix%22+milestone%3A3.0.0)