### PR TITLE
Extend `query` ::repo arg spec to IPrepareQuery

### DIFF
--- a/src/grafter_2/rdf/protocols.clj
+++ b/src/grafter_2/rdf/protocols.clj
@@ -59,7 +59,7 @@
 
 (defprotocol ITransactable
   "Low level protocol for transactions support.  Most users probably
-  want to use grafter-2.rdf.sesame/with-transaction"
+  want to use grafter-2.rdf4j.repository/with-transaction"
   (begin [repo] "Start a transaction")
   (commit [repo] "Commit a transaction")
   (rollback [repo] "Rollback a transaction"))

--- a/src/grafter_2/rdf4j/sparql.clj
+++ b/src/grafter_2/rdf4j/sparql.clj
@@ -6,7 +6,8 @@
             [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [grafter-2.rdf4j.io :as rio]
-            [grafter-2.rdf4j.repository :as repo :refer [->connection]])
+            [grafter-2.rdf4j.repository :as repo
+             :refer [->connection IPrepareQuery]])
   (:import java.util.regex.Pattern
            org.eclipse.rdf4j.rio.ntriples.NTriplesUtil
            org.eclipse.rdf4j.repository.RepositoryConnection))
@@ -125,7 +126,8 @@
 
 (s/def ::reasoning? boolean?)
 (s/def ::query-opts (s/keys :req-un [::reasoning?]))
-(s/def ::repo (partial instance? RepositoryConnection))
+
+(s/def ::repo (partial satisfies? IPrepareQuery))
 
 (s/def ::bound-value any?)
 


### PR DESCRIPTION
So that we can `query` anything that implements IPrepareQuery