### PR TITLE
Allow boolean false values to be bound in queries

### DIFF
--- a/src/grafter_2/rdf4j/sparql.clj
+++ b/src/grafter_2/rdf4j/sparql.clj
@@ -237,7 +237,7 @@
         prepped-query (repo/prepare-query repo pre-processed-qry nil opts)]
     (reduce (fn [pq [unbound-var val]]
               (when-not (or (sequential? val) (set? val))
-                (if (and val (satisfies? rio/IRDF4jConverter val))
+                (if (and (some? val) (satisfies? rio/IRDF4jConverter val))
                   (.setBinding pq (name unbound-var) (rio/->backend-type val))
                   (throw (ex-info (str "Could not coerce nil value into SPARQL binding for variable " unbound-var)
                                   {:variable unbound-var :bindings bindings :sparql-query sparql-query}))))


### PR DESCRIPTION
This fixes a bug where binding a boolean false value in a query would
cause the query to be rejected with a "Could not coerce nil value... "
exception.

This resolves #177