### PR TITLE
Fix NPE if remote repository fails to respond properly

### DIFF
--- a/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLSession.java
+++ b/src-java/grafter_sparql_repository/src/main/java/grafter_2/rdf/SPARQLSession.java
@@ -199,7 +199,11 @@ public class SPARQLSession extends SPARQLProtocolSession /*SparqlSession*/ {
                             throw new UnsupportedQueryLanguageException(errInfo.getErrorMessage());
                         }
                         else {
-                            throw new RepositoryException(errInfo.toString());
+                            if(errInfo != null) {
+                                throw new RepositoryException(errInfo.toString());
+                            } else {
+                                throw new RepositoryException("No Error Info Present, server may not have responded properly");
+                            }
                         }
                 }
             }


### PR DESCRIPTION
We're still raising an error, we now raise an exception that at least points the blame upstream.

We were seeing this NPE if the SPARQL endpoint dies during the request and doesn't appear to return a status code in the response.