### PR TITLE
Check CI build is still green

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ As of 0.9.0 the `grafter.tabular` library has been moved into a
 the core grafter library can focus on processing linked data.
 
 This part of the library is now considered deprecated.  If you depend
-on it you can still use it, and it may receive occaisional
+on it you can still use it, and it may receive occasional
 maintainance updates.
 
 If you're looking to start a greenfield project then you can easily

--- a/deps.edn
+++ b/deps.edn
@@ -5,6 +5,6 @@
 
  :aliases {:build {:deps {slipset/deps-deploy {:mvn/version "0.2.0"}
                           io.github.seancorfield/build-clj
-                          {:git/tag "v0.8.5" :git/sha "de693d0"}}
+                          {:git/tag "v0.9.2" :git/sha "9c9f078"}}
                    :ns-default build}}
  }

--- a/grafter.core/deps.edn
+++ b/grafter.core/deps.edn
@@ -21,5 +21,5 @@
 
                    :deps {lambdaisland/kaocha {:mvn/version "1.71.1119"}
                           io.github.seancorfield/build-clj
-                          {:git/tag "v0.6.3" :git/sha "9b8e09b"}}
+                          {:git/tag "v0.9.2" :git/sha "9c9f078"}}
                    :ns-default build}}}

--- a/grafter.core/package.json
+++ b/grafter.core/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "shadow-cljs": "^2.20.15"
+    "shadow-cljs": "^2.26.2"
   }
 }

--- a/grafter.core/yarn.lock
+++ b/grafter.core/yarn.lock
@@ -496,19 +496,19 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shadow-cljs-jar@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
-  integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
+shadow-cljs-jar@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz#0939d91c468b4bc5eab5a958f79e7ef5696fdf62"
+  integrity sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA==
 
-shadow-cljs@^2.20.15:
-  version "2.20.15"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.20.15.tgz#96ff6a09abd8c9c44952e101b9964eaabb4b5185"
-  integrity sha512-P+FNklygJSmYfQ6endfAeMe20+lmKp3C4Jb7oYoQWJVSj5Tleg1EUf4g/7yvRLOKgaj/G7wossw1mWAZxkkaGg==
+shadow-cljs@^2.26.2:
+  version "2.26.2"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.26.2.tgz#c9d443940d679c33696009598b01e02a176f6a67"
+  integrity sha512-xBJxBxSpfoVQLSDA+WN+ZgtnyA5qYf3EE4ARZpov0JOz0YBTdIQajnNYMs5+5OzCbbNfhWGLybyu/Pj4dIwsWw==
   dependencies:
     node-libs-browser "^2.2.1"
     readline-sync "^1.4.7"
-    shadow-cljs-jar "1.3.2"
+    shadow-cljs-jar "1.3.4"
     source-map-support "^0.4.15"
     which "^1.3.1"
     ws "^7.4.6"

--- a/grafter.io/deps.edn
+++ b/grafter.io/deps.edn
@@ -22,5 +22,5 @@
                   :main-opts ["-m" "kaocha.runner"]}
 
            :build {:deps {io.github.seancorfield/build-clj
-                          {:git/tag "v0.6.3" :git/sha "9b8e09b"}}
+                          {:git/tag "v0.9.2" :git/sha "9c9f078"}}
                    :ns-default build}}}


### PR DESCRIPTION
The Circle CI build hasn't been run for months. I wanted to trigger a build to see if it would still be green.

I made a couple of small changes to deps.edn to invalidate the Circle CI caches and then decided to keep them.

More specfically, I update shadow-cljs and build-clj versions.